### PR TITLE
Migrate Pydantic usage to V2

### DIFF
--- a/keisei/config_schema.py
+++ b/keisei/config_schema.py
@@ -5,7 +5,7 @@ Defines all configuration sections and their defaults.
 
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class EnvConfig(BaseModel):
@@ -97,14 +97,14 @@ class TrainingConfig(BaseModel):
         description="When to step the scheduler: 'epoch' (per PPO epoch) or 'update' (per minibatch update)",
     )
 
-    @validator("learning_rate")
+    @field_validator("learning_rate")
     # pylint: disable=no-self-argument
     def lr_positive(cls, v):
         if v <= 0:
             raise ValueError("learning_rate must be positive")
         return v
 
-    @validator("lr_schedule_type")
+    @field_validator("lr_schedule_type")
     def validate_lr_schedule_type(cls, v):  # pylint: disable=no-self-argument
         if v is not None and v not in ["linear", "cosine", "exponential", "step"]:
             raise ValueError(
@@ -112,7 +112,7 @@ class TrainingConfig(BaseModel):
             )
         return v
 
-    @validator("lr_schedule_step_on")
+    @field_validator("lr_schedule_step_on")
     def validate_lr_schedule_step_on(cls, v):  # pylint: disable=no-self-argument
         if v not in ["epoch", "update"]:
             raise ValueError("lr_schedule_step_on must be 'epoch' or 'update'")
@@ -140,21 +140,21 @@ class EvaluationConfig(BaseModel):
         False, description="Enable Weights & Biases logging for evaluation."
     )
 
-    @validator("evaluation_interval_timesteps")
+    @field_validator("evaluation_interval_timesteps")
     # pylint: disable=no-self-argument
     def evaluation_interval_positive(cls, v):
         if v <= 0:
             raise ValueError("evaluation_interval_timesteps must be positive")
         return v
 
-    @validator("num_games")
+    @field_validator("num_games")
     # pylint: disable=no-self-argument
     def num_games_positive(cls, v):
         if v <= 0:
             raise ValueError("num_games must be positive")
         return v
 
-    @validator("max_moves_per_game")
+    @field_validator("max_moves_per_game")
     # pylint: disable=no-self-argument
     def max_moves_positive(cls, v):
         if v <= 0:
@@ -218,14 +218,14 @@ class ParallelConfig(BaseModel):
         1000, description="Offset for worker random seeds to ensure diversity."
     )
 
-    @validator("num_workers")
+    @field_validator("num_workers")
     # pylint: disable=no-self-argument
     def workers_positive(cls, v):
         if v <= 0:
             raise ValueError("num_workers must be positive")
         return v
 
-    @validator("batch_size")
+    @field_validator("batch_size")
     # pylint: disable=no-self-argument
     def batch_size_positive(cls, v):
         if v <= 0:
@@ -252,5 +252,4 @@ class AppConfig(BaseModel):
     parallel: ParallelConfig
     demo: DemoConfig
 
-    class Config:
-        extra = "forbid"  # Disallow unknown fields for strict validation
+    model_config = {"extra": "forbid"}  # Disallow unknown fields for strict validation

--- a/keisei/core/ppo_agent.py
+++ b/keisei/core/ppo_agent.py
@@ -143,7 +143,7 @@ class PPOAgent:
         """
         self.model.train(is_training)
 
-        obs_tensor = torch.tensor(
+        obs_tensor = torch.as_tensor(
             obs, dtype=torch.float32, device=self.device
         ).unsqueeze(0)
 
@@ -198,7 +198,7 @@ class PPOAgent:
     def get_value(self, obs_np: np.ndarray) -> float:
         """Get the value prediction from the critic for a given NumPy observation."""
         self.model.eval()
-        obs_tensor = torch.tensor(
+        obs_tensor = torch.as_tensor(
             obs_np, dtype=torch.float32, device=self.device
         ).unsqueeze(0)
         with torch.no_grad():

--- a/keisei/training/training_loop_manager.py
+++ b/keisei/training/training_loop_manager.py
@@ -67,7 +67,7 @@ class TrainingLoopManager:
             self.parallel_manager = ParallelManager(
                 env_config=env_config,
                 model_config=model_config,
-                parallel_config=self.config.parallel.dict(),
+                parallel_config=self.config.parallel.model_dump(),
                 device=self.config.env.device,
             )
 
@@ -101,7 +101,7 @@ class TrainingLoopManager:
                 log_both(
                     f"Starting {self.config.parallel.num_workers} parallel workers..."
                 )
-                if self.parallel_manager.start_workers(self.trainer.agent.model):
+                if self.parallel_manager.start_workers(cast(nn.Module, self.trainer.agent.model)):
                     log_both("Parallel workers started successfully")
                 else:
                     log_both(

--- a/keisei/utils/utils.py
+++ b/keisei/utils/utils.py
@@ -135,7 +135,7 @@ def load_config(
         mapped_overrides = _map_flat_overrides(cli_overrides)
         _merge_overrides(config_data, mapped_overrides)
     try:
-        config = AppConfig.parse_obj(config_data)
+        config = AppConfig.model_validate(config_data)
     except ValidationError as e:
         log_error_to_stderr("Utils", "Configuration validation error:")
         log_error_to_stderr("Utils", str(e))
@@ -274,6 +274,8 @@ class PolicyOutputMapper:
                         and stored_move[0] is None
                         and stored_move[2] == move[2]
                         and stored_move[3] == move[3]
+                        and isinstance(stored_move[4], PieceType)
+                        and isinstance(move[4], PieceType)
                         and stored_move[4].value == move[4].value
                     ):  # Compare PieceType by value
                         idx = self.move_to_idx.get(stored_move)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -118,7 +118,7 @@ def test_train_resume_autodetect(tmp_path, mock_wandb_disabled):
             "base_port": 50000,
         },
     }
-    initial_agent_config = AppConfig.parse_obj(base_config_data)
+    initial_agent_config = AppConfig.model_validate(base_config_data)
 
     # Create model for dependency injection
     model = _create_test_model(initial_agent_config)
@@ -402,7 +402,7 @@ def test_train_explicit_resume(tmp_path, mock_wandb_disabled):
             "base_port": 50000,
         },
     }
-    initial_save_config_obj = AppConfig.parse_obj(initial_save_config_dict)
+    initial_save_config_obj = AppConfig.model_validate(initial_save_config_dict)
 
     checkpoint_save_dir = tmp_path / "initial_save_dir"  # As per logging.model_dir
     checkpoint_save_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- convert all validators to `@field_validator`
- switch config models to use `model_config`
- update config loading to use `model_validate`
- update parallel manager to use `model_dump`
- adapt tests for new API
- fix mypy errors around PieceType and worker startup
- remove stray `src/keisei` submodule file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840553802788323b93a80ae5ff4bfe0