### PR TITLE
Update README and remove stray submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For comprehensive technical details, see:
 - **Advanced PPO Implementation**: Clipped surrogate objectives, entropy regularization, and Generalized Advantage Estimation (GAE)
 - **Mixed Precision Training**: Automatic Mixed Precision (AMP) with GradScaler for memory efficiency and speed
 - **Distributed Training Support**: DistributedDataParallel (DDP) for multi-GPU training
+- **Parallel Self-Play Support**: Multi-process experience collection with `training/parallel`
 - **Intelligent Checkpointing**: Automatic model saving with resumption capabilities
 - **Gradient Management**: Configurable gradient clipping and optimization stability controls
 
@@ -69,8 +70,10 @@ For comprehensive technical details, see:
 - **Pydantic Configuration**: Type-safe, validated configuration with YAML loading
 - **Manager-Based Architecture**: 9 specialized managers for clean separation of concerns
 - **Rich Console UI**: Real-time training visualization with progress bars and metrics
+- **Unified Logger**: Consistent Rich-formatted logging via `utils/unified_logger.py`
 - **Comprehensive Logging**: Structured logging with file output and console formatting
 - **Weights & Biases Integration**: Professional experiment tracking and model artifact management
+- **Profiling Utilities**: Lightweight timing and cProfile helpers for development
 
 ### Evaluation & Monitoring
 - **Multi-Opponent Evaluation**: Test against random, heuristic, and other trained agents
@@ -83,6 +86,7 @@ For comprehensive technical details, see:
 - **Comprehensive Test Suite**: Unit tests, integration tests, and performance benchmarks
 - **Code Quality Tools**: Black formatting, mypy type checking, and security scanning
 - **Extensive Documentation**: Complete API documentation and usage guides
+- **Profiling Helpers**: Timing and cProfile utilities for performance debugging
 
 ## System Architecture
 
@@ -310,12 +314,15 @@ keisei/
 │
 ├── keisei/                     # Core library package
 │   ├── config_schema.py        # Pydantic configuration models
+│   ├── constants.py            # Shared board and observation constants
 │   │
 │   ├── core/                   # Core RL components
 │   │   ├── actor_critic_protocol.py # Model interface definition
+│   │   ├── base_actor_critic.py # Common ActorCritic helpers
 │   │   ├── neural_network.py   # Basic ActorCritic implementation
 │   │   ├── ppo_agent.py        # PPO algorithm implementation
 │   │   ├── experience_buffer.py # Experience storage and GAE
+│   │   ├── scheduler_factory.py # LR scheduler creation helpers
 │   │   └── __init__.py
 │   │
 │   ├── shogi/                  # Shogi game engine
@@ -345,6 +352,12 @@ keisei/
 │   │   ├── display_manager.py  # Rich UI and visualization
 │   │   ├── callback_manager.py # Training callbacks and events
 │   │   ├── setup_manager.py    # Component initialization
+│   │   ├── parallel/           # Multi-process experience collection
+│   │   │   ├── parallel_manager.py # Worker orchestration
+│   │   │   ├── self_play_worker.py # Self-play worker process
+│   │   │   ├── communication.py    # IPC utilities
+│   │   │   ├── model_sync.py       # Model synchronization
+│   │   │   └── utils.py            # Compression helpers
 │   │   └── utils.py            # Training utilities
 │   │
 │   ├── evaluation/             # Evaluation system
@@ -357,6 +370,8 @@ keisei/
 │       ├── checkpoint.py       # Checkpoint management utilities
 │       ├── move_formatting.py  # Move display and formatting
 │       ├── opponents.py        # Opponent implementations
+│       ├── unified_logger.py   # Rich console logging helper
+│       ├── profiling.py        # Development profiling tools
 │       ├── utils.py            # Core utilities and policy mapping
 │       └── __init__.py
 │
@@ -385,10 +400,11 @@ keisei/
 ```
 
 **Key Directories:**
-- **`keisei/core/`**: Core reinforcement learning components (PPO, neural networks, experience buffer)
+- **`keisei/core/`**: Core reinforcement learning components (PPO, base networks, schedulers)
 - **`keisei/shogi/`**: Complete Shogi game implementation with full rule support
-- **`keisei/training/`**: Manager-based training infrastructure with modular components
+- **`keisei/training/`**: Manager-based training infrastructure with parallel self-play support
 - **`keisei/evaluation/`**: Comprehensive evaluation system with multi-opponent support
+- **`keisei/utils/`**: Unified logger, profiling helpers, and utility functions
 - **`docs/`**: Extensive documentation including design documents and component details
 
 ## Technical Details

--- a/docs/2. CODE_MAP.md
+++ b/docs/2. CODE_MAP.md
@@ -43,6 +43,7 @@ All `shogi/*` modules:
 * `shogi_move_execution.py`
 * `shogi_game_io.py`
 * `shogi/features.py`
+* `constants.py` (board and observation constants)
 
 **Reviewer Watch-list (issues & risks):**
 
@@ -154,13 +155,18 @@ Implements the PPO algorithm (`PPOAgent`) and the experience replay buffer (`Exp
 ## 7. Training Orchestration
 
 **Sections & Purpose:**
-The main `Trainer` class orchestrates the entire training process: coordinating managers, handling PPO updates, managing callbacks, and overseeing the training loop (via `TrainingLoopManager`).
+The main `Trainer` class orchestrates the entire training process: coordinating managers, handling PPO updates, managing callbacks, and overseeing the training loop (via `TrainingLoopManager`). Includes optional parallel self-play via `ParallelManager`.
 
 **Core / Supporting Files:**
 
 * `training/trainer.py`
 * `training/training_loop_manager.py`
 * `training/callbacks.py`
+* `training/parallel/parallel_manager.py`
+* `training/parallel/self_play_worker.py`
+* `training/parallel/communication.py`
+* `training/parallel/model_sync.py`
+* `training/parallel/utils.py`
 
 **Reviewer Watch-list (issues & risks):**
 
@@ -219,13 +225,17 @@ Rich-based Text UI (TUI) for displaying live training progress, metrics, and log
 ## 10. Logging & Persistence
 
 **Sections & Purpose:**
-Utilities for file-based logging (`TrainingLogger`, `EvaluationLogger`), model checkpointing (save/load, migration for input-channel changes), and W\&B artifact management.
+Utilities for file-based logging (`TrainingLogger`, `EvaluationLogger`), model checkpointing (save/load, migration for input-channel changes), and W\&B artifact management. Unified console logging via `UnifiedLogger` and performance profiling helpers.
 
 **Core / Supporting Files:**
 
-* `utils/utils.py` (Loggers) * `utils/checkpoint.py` * `training/model_manager.py` (checkpointing, W\&B artifacts)
+* `utils/utils.py` (TrainingLogger, EvaluationLogger)
+* `utils/unified_logger.py` (shared Rich console logger)
+* `utils/profiling.py` (timing and cProfile helpers)
+* `utils/checkpoint.py`
+* `training/model_manager.py` (checkpointing, W&B artifacts)
 * `training/callbacks.py` (triggers saving)
-* `core/ppo_agent.py` (contains `save_model`, `load_model`) **Reviewer Watch-list (issues & risks):**
+* `core/ppo_agent.py` (contains `save_model`, `load_model`)
 
 * **Logging Consistency:**
   Mixed `print` statements and formal logger usage—standardise on logger objects.
@@ -246,6 +256,7 @@ Command-Line Interfaces (CLIs) for training and evaluation, package structure (`
 
 * Root `__init__.py` & all sub-package `__init__.py` files
 * `training/train.py`
+* `keisei/__init__.py` (public package API)
 * `training/train_wandb_sweep.py`
 * `evaluation/evaluate.py`
 
@@ -432,6 +443,7 @@ graph LR
 
     style A fill:#lightblue,stroke:#333,stroke-width:2px
     style B fill:#lightgrey,stroke:#333,stroke-width:2px
+    style J fill:#lightgrey,stroke:#333,stroke-width:2px
 ```
 **Interactions:** `PPOAgent` uses a neural model to select actions and evaluate states, and `SchedulerFactory` for learning rate schedules. Experiences (observations, actions, rewards) are stored in `ExperienceBuffer`. The agent retrieves batches from the buffer, calculates GAE, and performs PPO updates on the model. ---
 
@@ -498,6 +510,12 @@ graph LR
         H["core/ppo_agent.py"]
         I["core/experience_buffer.py"]
     end
+    subgraph Parallel Training
+        J["training/parallel/parallel_manager.py"]
+        K["training/parallel/self_play_worker.py"]
+        L["training/parallel/model_sync.py"]
+        M["training/parallel/communication.py"]
+    end
 
     A -- Instantiates & Coordinates --> D
     A -- Instantiates & Coordinates --> E
@@ -507,6 +525,10 @@ graph LR
     A -- Instantiates & Coordinates --> I
     A -- Instantiates & Delegates Loop to --> B
     A -- Manages & Triggers --> C
+    A -- Coordinates --> J
+    J -- Spawns --> K
+    J -- Syncs Model via --> L
+    J -- Communicates via --> M
 
     B -- Executes Training Loop --> A
     B -- Uses --> G
@@ -519,6 +541,7 @@ graph LR
 
     style A fill:#lightblue,stroke:#333,stroke-width:2px
     style B fill:#lightgrey,stroke:#333,stroke-width:2px
+    style J fill:#lightgrey,stroke:#333,stroke-width:2px
 ```
 **Interactions:** The `Trainer` is the central orchestrator, initializing and coordinating various managers. It delegates the main training iteration logic to `TrainingLoopManager`. Callbacks are registered with the `Trainer` and triggered during the loop to perform tasks like checkpointing and evaluation.
 
@@ -588,6 +611,8 @@ graph LR
     subgraph Loggers
         A1["utils/utils.py (TrainingLogger)"]
         A2["utils/utils.py (EvaluationLogger)"]
+        A3["utils/unified_logger.py (UnifiedLogger)"]
+        A4["utils/profiling.py (Profiling Helpers)"]
     end
 
     subgraph Checkpoint/Model Management
@@ -609,6 +634,9 @@ graph LR
 
     C1 -- Uses --> A1
     C3 -- Uses --> A2
+    C1 -- Uses --> A3
+    C3 -- Uses --> A3
+    C1 -- Uses --> A4
     A1 --> E1
     A2 --> E1
 
@@ -622,6 +650,8 @@ graph LR
 
 
     style B1 fill:#lightblue,stroke:#333,stroke-width:2px
+    style A3 fill:#lightgrey,stroke:#333,stroke-width:2px
+    style A4 fill:#lightgrey,stroke:#333,stroke-width:2px
 ```
 **Interactions:** `TrainingLogger` and `EvaluationLogger` write to log files. `ModelManager` is central to saving/loading models and checkpoints to the file system and W&B, often triggered by callbacks or the `Trainer`. `PPOAgent` contains the underlying model state save/load logic. `utils/checkpoint.py` provides specialized loading.
 

--- a/docs/component_audit/config_schema.md
+++ b/docs/component_audit/config_schema.md
@@ -1,0 +1,31 @@
+# Software Documentation Template for Subsystems - Configuration Schema
+
+## 📘 config_schema.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Defines the Pydantic data models that represent all configuration options for the Keisei system. This includes environment, model, training, and evaluation settings with validation rules and default values.
+* **Key Responsibilities:**
+  - Provide strongly typed configuration classes
+  - Enforce validation and defaulting of configuration options
+  - Serve as the single source of truth for application configuration
+
+### 2. Dependencies 🔗
+
+* **External:** `pydantic`, `typing`
+* **Internal:** none
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Extend these configuration models when introducing new features to ensure that all options are validated consistently.

--- a/docs/component_audit/constants.md
+++ b/docs/component_audit/constants.md
@@ -1,0 +1,30 @@
+# Software Documentation Template for Subsystems - Project Constants
+
+## 📘 constants.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Centralizes numerical constants and static values used throughout the application. By defining them in one place the codebase avoids magic numbers and maintains consistency between modules.
+* **Key Responsibilities:**
+  - Provide board and action space constants for the Shogi environment
+  - Define observation channel indices and normalization factors
+  - Serve as a shared reference for other modules
+
+### 2. Dependencies 🔗
+
+None
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Update these constants carefully as downstream modules may rely on them for tensor shapes and normalization logic.

--- a/docs/component_audit/core_base_actor_critic.md
+++ b/docs/component_audit/core_base_actor_critic.md
@@ -1,0 +1,31 @@
+# Software Documentation Template for Subsystems - Base Actor Critic
+
+## 📘 base_actor_critic.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/core/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Provides an abstract base class implementing shared logic for Actor-Critic neural network models. Subclasses implement the actual forward network but reuse the action and value calculation helpers defined here.
+* **Key Responsibilities:**
+  - Define the common interface used by PPO agents
+  - Implement `get_action_and_value` and `evaluate_actions` helpers
+  - Require subclasses to implement `forward`
+
+### 2. Dependencies 🔗
+
+* **Internal:** `keisei.core.actor_critic_protocol`, `keisei.utils.unified_logger`
+* **External:** `torch`, `torch.nn`
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Use this base class when creating new network architectures so that they are compatible with the PPO agent without rewriting boilerplate logic.

--- a/docs/component_audit/core_scheduler_factory.md
+++ b/docs/component_audit/core_scheduler_factory.md
@@ -1,0 +1,30 @@
+# Software Documentation Template for Subsystems - Scheduler Factory
+
+## 📘 scheduler_factory.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/core/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Factory helper for creating PyTorch learning rate schedulers used in PPO training. Provides a single entry point for selecting scheduler strategies such as cosine annealing or exponential decay.
+* **Key Responsibilities:**
+  - Create and configure LR scheduler instances based on configuration
+  - Hide conditional logic for scheduler selection from training loops
+
+### 2. Dependencies 🔗
+
+* **External:** `torch.optim.lr_scheduler`
+* **Internal:** none
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Extend this factory when adding new learning rate schedule types so they can be configured without modifying training code.

--- a/docs/component_audit/keisei_init.md
+++ b/docs/component_audit/keisei_init.md
@@ -1,0 +1,34 @@
+# Software Documentation Template for Subsystems - Keisei Package
+
+## 📘 __init__.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Provides the package initialization for the top level `keisei` package. It re-exports commonly used classes such as `ShogiGame` and evaluation utilities so that users can import them directly from `keisei`.
+* **Key Responsibilities:**
+  - Define the public API of the package through `__all__`
+  - Re-export central types and helpers from submodules
+  - Simplify user imports for evaluation entry points
+
+### 2. Dependencies 🔗
+
+* **Internal:**
+  - `keisei.shogi.shogi_core_definitions`
+  - `keisei.shogi.shogi_game`
+  - `keisei.evaluation.evaluate`
+* **External:** None
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+The package `__init__` keeps the import surface small and friendly. When extending the project, update `__all__` here to expose new high-level utilities.

--- a/docs/component_audit/training_parallel_communication.md
+++ b/docs/component_audit/training_parallel_communication.md
@@ -1,0 +1,30 @@
+# Software Documentation Template for Subsystems - Worker Communicator
+
+## 📘 communication.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Implements queue-based communication between the main training process and worker processes. Handles experience collection messages and model update notifications.
+* **Key Responsibilities:**
+  - Provide non-blocking send/receive utilities with timeout handling
+  - Support compression of large numpy arrays for efficiency
+
+### 2. Dependencies 🔗
+
+* **Internal:** `.utils` for compression helpers
+* **External:** `multiprocessing`, `numpy`, `torch`
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+This module is central to the parallel training workflow; monitor its queues and log outputs when debugging worker issues.

--- a/docs/component_audit/training_parallel_init.md
+++ b/docs/component_audit/training_parallel_init.md
@@ -1,0 +1,30 @@
+# Software Documentation Template for Subsystems - Parallel Training Package
+
+## 📘 training/parallel/__init__.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Initializes the parallel training subsystem and exposes its primary classes. This package enables experience collection across multiple worker processes.
+* **Key Responsibilities:**
+  - Re-export `ParallelManager`, `SelfPlayWorker`, `ModelSynchronizer`, and helpers
+  - Provide package metadata and versioning
+
+### 2. Dependencies 🔗
+
+* **Internal:** other modules in `keisei.training.parallel`
+* **External:** `multiprocessing`
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Import `ParallelManager` from this package to coordinate self-play workers in your training loop.

--- a/docs/component_audit/training_parallel_model_sync.md
+++ b/docs/component_audit/training_parallel_model_sync.md
@@ -1,0 +1,30 @@
+# Software Documentation Template for Subsystems - Model Synchronizer
+
+## 📘 model_sync.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Handles efficient synchronization of model weights between the main training process and worker processes. Supports optional gzip compression and version tracking.
+* **Key Responsibilities:**
+  - Serialize and compress model parameters for transmission
+  - Apply received weights to worker models safely
+
+### 2. Dependencies 🔗
+
+* **Internal:** `.utils` for compression helpers
+* **External:** `torch`, `numpy`, `gzip`
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Use the synchronizer to ensure workers receive the latest policy without incurring large transfer overhead.

--- a/docs/component_audit/training_parallel_parallel_manager.md
+++ b/docs/component_audit/training_parallel_parallel_manager.md
@@ -1,0 +1,31 @@
+# Software Documentation Template for Subsystems - Parallel Manager
+
+## 📘 parallel_manager.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Coordinates multiple self-play workers and orchestrates the overall parallel experience collection process.
+* **Key Responsibilities:**
+  - Spawn and monitor worker processes
+  - Collect experiences from a shared queue
+  - Trigger model synchronization events
+
+### 2. Dependencies 🔗
+
+* **Internal:** `WorkerCommunicator`, `ModelSynchronizer`, `SelfPlayWorker`
+* **External:** `torch`, `multiprocessing`
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Use `ParallelManager` as the entry point for multi-process training setups.

--- a/docs/component_audit/training_parallel_self_play_worker.md
+++ b/docs/component_audit/training_parallel_self_play_worker.md
@@ -1,0 +1,31 @@
+# Software Documentation Template for Subsystems - Self Play Worker
+
+## 📘 self_play_worker.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Implements the worker process that runs self-play games and sends experience batches to the main process.
+* **Key Responsibilities:**
+  - Interact with the Shogi environment to generate training data
+  - Maintain its own copy of the model for inference
+  - Communicate results and receive updates via the communicator
+
+### 2. Dependencies 🔗
+
+* **Internal:** `keisei.shogi`, `keisei.core.experience_buffer`, `WorkerCommunicator`
+* **External:** `torch`, `numpy`, `multiprocessing`
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Workers should be started and stopped through `ParallelManager` rather than directly instantiated in user code.

--- a/docs/component_audit/training_parallel_utils.md
+++ b/docs/component_audit/training_parallel_utils.md
@@ -1,0 +1,30 @@
+# Software Documentation Template for Subsystems - Parallel Utilities
+
+## 📘 utils.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Contains helper functions for compressing and decompressing numpy arrays during inter-process communication.
+* **Key Responsibilities:**
+  - Provide gzip-based compression routines
+  - Record compression ratios for profiling
+
+### 2. Dependencies 🔗
+
+* **External:** `gzip`, `numpy`
+* **Internal:** none
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+These utilities are used by both the communicator and the model synchronizer.

--- a/docs/component_audit/utils_profiling.md
+++ b/docs/component_audit/utils_profiling.md
@@ -1,0 +1,31 @@
+# Software Documentation Template for Subsystems - Profiling Helpers
+
+## 📘 profiling.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/utils/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Provides lightweight timing and cProfile helpers used during development to measure performance of critical code sections.
+* **Key Responsibilities:**
+  - Context managers for quick timing of code blocks
+  - Decorators for profiling functions with cProfile
+  - Logging helpers for formatted profiling output
+
+### 2. Dependencies 🔗
+
+* **External:** `cProfile`, `time`
+* **Internal:** `keisei.utils.unified_logger`
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Wrap expensive operations with these helpers to monitor training throughput and identify bottlenecks.

--- a/docs/component_audit/utils_unified_logger.md
+++ b/docs/component_audit/utils_unified_logger.md
@@ -1,0 +1,31 @@
+# Software Documentation Template for Subsystems - Unified Logger
+
+## 📘 unified_logger.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/utils/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Offers a consistent logging interface used across training and evaluation components. Provides colored console output via Rich and optional timestamping.
+* **Key Responsibilities:**
+  - Format messages with Rich to enhance readability
+  - Send log output to stderr to avoid interfering with tqdm progress bars
+  - Provide simple helper methods for info, warning, and error logs
+
+### 2. Dependencies 🔗
+
+* **External:** `rich`
+* **Internal:** none
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Use this logger instead of plain `print` statements for uniform log styling.


### PR DESCRIPTION
## Summary
- integrate newly documented modules in the README
- highlight unified logger and profiling utilities
- add parallel training components to the project structure
- remove leftover `src/keisei` submodule entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408fe43ed483238cc781fc8373fcc9