### PR TITLE
Add Elo registry and board move display

### DIFF
--- a/default_config.yaml
+++ b/default_config.yaml
@@ -190,9 +190,12 @@ evaluation:
   
   # File path for evaluation game logs and results
   log_file_path_eval: "eval_log.txt"
-  
+
   # Enable Weights & Biases logging for evaluation metrics
   wandb_log_eval: false
+  elo_registry_path: null
+  agent_id: null
+  opponent_id: null
 # =============================================================================
 # LOGGING CONFIGURATION (LoggingConfig)
 # =============================================================================
@@ -306,3 +309,5 @@ display:
   elo_k_factor: 32.0                # K-factor for Elo updates
   dashboard_height_ratio: 2         # Relative height for dashboard section
   progress_bar_height: 4            # Height of progress bar section
+  show_text_moves: true             # Display recent moves under board
+  move_list_length: 10              # Number of moves to show

--- a/keisei/config_schema.py
+++ b/keisei/config_schema.py
@@ -139,6 +139,15 @@ class EvaluationConfig(BaseModel):
     wandb_log_eval: bool = Field(
         False, description="Enable Weights & Biases logging for evaluation."
     )
+    elo_registry_path: Optional[str] = Field(
+        None, description="Path to Elo registry JSON file"
+    )
+    agent_id: Optional[str] = Field(
+        None, description="Identifier for the evaluated model"
+    )
+    opponent_id: Optional[str] = Field(
+        None, description="Identifier for the opponent model"
+    )
 
     @field_validator("evaluation_interval_timesteps")
     # pylint: disable=no-self-argument
@@ -258,6 +267,12 @@ class DisplayConfig(BaseModel):
     elo_k_factor: float = Field(32.0, description="Elo K-factor")
     dashboard_height_ratio: int = Field(2, description="Layout ratio for dashboard")
     progress_bar_height: int = Field(4, description="Progress bar height")
+    show_text_moves: bool = Field(
+        True, description="Display recent moves under the board when demo mode is active"
+    )
+    move_list_length: int = Field(
+        10, description="Number of recent moves to display"
+    )
 
 
 class AppConfig(BaseModel):

--- a/keisei/evaluation/elo_registry.py
+++ b/keisei/evaluation/elo_registry.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List
+
+
+@dataclass
+class EloRegistry:
+    """Persistent registry of Elo ratings for agents."""
+
+    path: Path
+    default_rating: float = 1500.0
+    k_factor: float = 32.0
+    ratings: Dict[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.load()
+
+    # Persistence helpers
+    def load(self) -> None:
+        if self.path.exists():
+            try:
+                with self.path.open("r", encoding="utf-8") as f:
+                    self.ratings = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                self.ratings = {}
+        else:
+            self.ratings = {}
+
+    def save(self) -> None:
+        try:
+            with self.path.open("w", encoding="utf-8") as f:
+                json.dump(self.ratings, f, indent=2)
+        except OSError:
+            pass
+
+    # Rating helpers
+    def get_rating(self, model_id: str) -> float:
+        return float(self.ratings.get(model_id, self.default_rating))
+
+    def _expected_score(self, rating_a: float, rating_b: float) -> float:
+        return 1.0 / (1.0 + 10 ** ((rating_b - rating_a) / 400))
+
+    def update_ratings(
+        self, model_a_id: str, model_b_id: str, results: List[str]
+    ) -> None:
+        """Update ratings based on a series of game results."""
+
+        rating_a = self.get_rating(model_a_id)
+        rating_b = self.get_rating(model_b_id)
+
+        for res in results:
+            if res == "agent_win":
+                score_a, score_b = 1.0, 0.0
+            elif res == "opponent_win":
+                score_a, score_b = 0.0, 1.0
+            else:
+                score_a = score_b = 0.5
+
+            exp_a = self._expected_score(rating_a, rating_b)
+            exp_b = self._expected_score(rating_b, rating_a)
+
+            rating_a += self.k_factor * (score_a - exp_a)
+            rating_b += self.k_factor * (score_b - exp_b)
+
+        self.ratings[model_a_id] = rating_a
+        self.ratings[model_b_id] = rating_b

--- a/keisei/training/display_components.py
+++ b/keisei/training/display_components.py
@@ -20,8 +20,10 @@ class DisplayComponent(Protocol):
 class ShogiBoard:
     """ASCII representation of the current Shogi board state."""
 
-    def __init__(self, use_unicode: bool = True) -> None:
+    def __init__(self, use_unicode: bool = True, show_moves: bool = False, max_moves: int = 10) -> None:
         self.use_unicode = use_unicode
+        self.show_moves = show_moves
+        self.max_moves = max_moves
 
     def _piece_to_symbol(self, piece) -> str:
         if not piece:
@@ -57,12 +59,28 @@ class ShogiBoard:
             lines.append("".join(line_parts))
         return "\n".join(lines)
 
-    def render(self, board_state=None) -> RenderableType:  # type: ignore[override]
+    def _move_to_usi(self, move_tuple, policy_mapper) -> str:
+        try:
+            return policy_mapper.shogi_move_to_usi(move_tuple)
+        except Exception:
+            return str(move_tuple)
+
+    def render(self, board_state=None, move_history=None, policy_mapper=None) -> RenderableType:  # type: ignore[override]
         if not board_state:
             return Panel(Text("No active game"), title="Shogi Board")
 
         ascii_board = self._generate_ascii_board(board_state)
-        return Panel(Text(ascii_board), title="Current Position", border_style="blue")
+        board_panel = Panel(Text(ascii_board), title="Current Position", border_style="blue")
+
+        if not self.show_moves or not move_history or policy_mapper is None:
+            return board_panel
+
+        last_moves = move_history[-self.max_moves :]
+        lines = [self._move_to_usi(mv, policy_mapper) for mv in last_moves]
+        start_idx = len(move_history) - len(last_moves) + 1
+        formatted = [f"{start_idx + i:3d}: {mv}" for i, mv in enumerate(lines)]
+        moves_panel = Panel(Text("\n".join(formatted)), border_style="yellow", title="Recent Moves")
+        return Group(board_panel, moves_panel)
 
 
 class Sparkline:

--- a/keisei/training/step_manager.py
+++ b/keisei/training/step_manager.py
@@ -82,6 +82,7 @@ class StepManager:
         self.policy_mapper = policy_mapper
         self.experience_buffer = experience_buffer
         self.device = torch.device(config.env.device)
+        self.move_history: List[Tuple] = []
 
     def execute_step(
         self,
@@ -416,6 +417,7 @@ class StepManager:
             dtype=torch.float32,
             device=self.device,
         ).unsqueeze(0)
+        self.move_history.clear()
 
         return EpisodeState(
             current_obs=reset_obs,
@@ -512,6 +514,7 @@ class StepManager:
             None,  # wandb_data
             "info",  # log_level
         )
+        self.move_history.append(selected_move)
 
         # Add delay for easier observation
         demo_delay = self.config.demo.demo_mode_delay

--- a/tests/evaluation/test_elo_registry.py
+++ b/tests/evaluation/test_elo_registry.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+from keisei.evaluation.elo_registry import EloRegistry
+
+
+def test_elo_registry_load_update_save(tmp_path):
+    path = tmp_path / "elo.json"
+    registry = EloRegistry(path)
+    assert registry.get_rating("A") == 1500.0
+    results = ["agent_win", "agent_win", "draw", "opponent_win"]
+    registry.update_ratings("A", "B", results)
+    registry.save()
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert "A" in data and "B" in data
+    assert data["A"] != 1500.0

--- a/tests/evaluation/test_evaluate_evaluator.py
+++ b/tests/evaluation/test_evaluate_evaluator.py
@@ -88,6 +88,9 @@ def test_evaluator_class_basic(monkeypatch, tmp_path, policy_mapper):
         wandb_entity_eval=None,
         wandb_run_name_eval=None,
         logger_also_stdout=False,
+        elo_registry_path=str(tmp_path / "elo.json"),
+        agent_id="agentA",
+        opponent_id="oppB",
     )
 
     results = evaluator.evaluate()
@@ -104,3 +107,5 @@ def test_evaluator_class_basic(monkeypatch, tmp_path, policy_mapper):
         log_content = f.read()
     assert "Starting Shogi Agent Evaluation" in log_content
     assert "[Evaluator] Evaluation Summary:" in log_content
+    elo_file = tmp_path / "elo.json"
+    assert elo_file.exists()


### PR DESCRIPTION
## Summary
- integrate Elo rating registry with evaluator and config
- store last moves and display them under the board in demo mode
- show more metric trends
- add tests for EloRegistry and update evaluator tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840fd068fc083239ac31d96f77af96c