### PR TITLE
Add script to sync keisei audit docs

### DIFF
--- a/docs/component_audit/keisei___init__.md
+++ b/docs/component_audit/keisei___init__.md
@@ -1,0 +1,118 @@
+# Software Documentation Template for Subsystems - __init__
+
+## 📘 __init__.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+DRL Shogi Client - A reinforcement learning agent for Japanese chess (Shogi).
+### 2. Modules 📦
+
+* **Dependencies:**
+- from .evaluation.evaluate import execute_full_evaluation_run
+- from .shogi.shogi_core_definitions import Color, MoveTuple, Piece, PieceType
+- from .shogi.shogi_game import ShogiGame
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_config_schema.md
+++ b/docs/component_audit/keisei_config_schema.md
@@ -1,0 +1,125 @@
+# Software Documentation Template for Subsystems - config_schema
+
+## 📘 config_schema.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Pydantic configuration schema for Keisei DRL Shogi Client.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import Literal, Optional
+- from pydantic import BaseModel, Field, field_validator
+### 3. Classes 🏛️
+
+- `EnvConfig`: No docstring
+- `TrainingConfig`: No docstring
+- `EvaluationConfig`: No docstring
+- `LoggingConfig`: No docstring
+- `WandBConfig`: No docstring
+- `ParallelConfig`: No docstring
+- `DemoConfig`: No docstring
+- `DisplayConfig`: Configuration for optional TUI display features.
+- `AppConfig`: No docstring
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_constants.md
+++ b/docs/component_audit/keisei_constants.md
@@ -1,0 +1,116 @@
+# Software Documentation Template for Subsystems - constants
+
+## 📘 constants.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+constants.py: Application-wide constants for the Keisei Shogi RL system.
+### 2. Modules 📦
+
+* **Dependencies:**
+*None*
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_core___init__.md
+++ b/docs/component_audit/keisei_core___init__.md
@@ -1,0 +1,117 @@
+# Software Documentation Template for Subsystems - __init__
+
+## 📘 __init__.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/core/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+No docstring found—please add a summary
+### 2. Modules 📦
+
+* **Dependencies:**
+- from .base_actor_critic import BaseActorCriticModel
+- from .neural_network import ActorCritic
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_core_actor_critic_protocol.md
+++ b/docs/component_audit/keisei_core_actor_critic_protocol.md
@@ -1,0 +1,118 @@
+# Software Documentation Template for Subsystems - actor_critic_protocol
+
+## 📘 actor_critic_protocol.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/core/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Protocol definition for Actor-Critic models in Keisei.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import Any, Dict, Iterator, Optional, Protocol, Tuple
+- import torch
+- import torch.nn as nn
+### 3. Classes 🏛️
+
+- `ActorCriticProtocol`: Protocol defining the interface that all Actor-Critic models must implement.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_core_base_actor_critic.md
+++ b/docs/component_audit/keisei_core_base_actor_critic.md
@@ -1,0 +1,123 @@
+# Software Documentation Template for Subsystems - base_actor_critic
+
+## 📘 base_actor_critic.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/core/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Base Actor-Critic model implementation for Keisei.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import sys
+- from abc import ABC, abstractmethod
+- from typing import Optional, Tuple
+- import torch
+- import torch.nn as nn
+- import torch.nn.functional as F
+- from keisei.utils.unified_logger import log_error_to_stderr
+- from .actor_critic_protocol import ActorCriticProtocol
+### 3. Classes 🏛️
+
+- `BaseActorCriticModel`: Abstract base class for Actor-Critic models that implements shared methods.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_core_experience_buffer.md
+++ b/docs/component_audit/keisei_core_experience_buffer.md
@@ -1,0 +1,120 @@
+# Software Documentation Template for Subsystems - experience_buffer
+
+## 📘 experience_buffer.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/core/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Minimal ExperienceBuffer for DRL Shogi Client.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from dataclasses import dataclass
+- from typing import Dict, List, Optional
+- import torch  # Ensure torch is imported
+- from keisei.utils.unified_logger import log_warning_to_stderr
+### 3. Classes 🏛️
+
+- `Experience`: Single experience transition for parallel collection.
+- `ExperienceBuffer`: Experience buffer for storing transitions during RL training.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_core_neural_network.md
+++ b/docs/component_audit/keisei_core_neural_network.md
@@ -1,0 +1,117 @@
+# Software Documentation Template for Subsystems - neural_network
+
+## 📘 neural_network.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/core/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Minimal ActorCritic neural network for DRL Shogi Client (dummy forward pass).
+### 2. Modules 📦
+
+* **Dependencies:**
+- from torch import nn
+- from .base_actor_critic import BaseActorCriticModel
+### 3. Classes 🏛️
+
+- `ActorCritic`: Actor-Critic neural network for Shogi RL agent (PPO-ready).
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_core_ppo_agent.md
+++ b/docs/component_audit/keisei_core_ppo_agent.md
@@ -1,0 +1,128 @@
+# Software Documentation Template for Subsystems - ppo_agent
+
+## 📘 ppo_agent.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/core/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Minimal PPOAgent for DRL Shogi Client.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import os
+- import sys  # For stderr
+- from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+- import numpy as np
+- import torch
+- import torch.nn.functional as F
+- from torch.cuda.amp import GradScaler
+- from keisei.config_schema import AppConfig
+- from keisei.core.actor_critic_protocol import ActorCriticProtocol
+- from keisei.core.experience_buffer import ExperienceBuffer
+- from keisei.core.scheduler_factory import SchedulerFactory
+- from keisei.utils import PolicyOutputMapper
+- from keisei.utils.unified_logger import log_error_to_stderr, log_info_to_stderr
+### 3. Classes 🏛️
+
+- `PPOAgent`: Proximal Policy Optimization agent for Shogi (PPO logic).
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_core_scheduler_factory.md
+++ b/docs/component_audit/keisei_core_scheduler_factory.md
@@ -1,0 +1,118 @@
+# Software Documentation Template for Subsystems - scheduler_factory
+
+## 📘 scheduler_factory.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/core/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Learning rate scheduler factory for PPO training.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import Any, Dict, Optional
+- import torch
+- from torch.optim.lr_scheduler import CosineAnnealingLR, ExponentialLR, LambdaLR, StepLR
+### 3. Classes 🏛️
+
+- `SchedulerFactory`: Factory for creating PyTorch learning rate schedulers.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_evaluation___init__.md
+++ b/docs/component_audit/keisei_evaluation___init__.md
@@ -1,0 +1,116 @@
+# Software Documentation Template for Subsystems - __init__
+
+## 📘 __init__.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/evaluation/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+No docstring found—please add a summary
+### 2. Modules 📦
+
+* **Dependencies:**
+*None*
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_evaluation_elo_registry.md
+++ b/docs/component_audit/keisei_evaluation_elo_registry.md
@@ -1,0 +1,120 @@
+# Software Documentation Template for Subsystems - elo_registry
+
+## 📘 elo_registry.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/evaluation/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+No docstring found—please add a summary
+### 2. Modules 📦
+
+* **Dependencies:**
+- from __future__ import annotations
+- import json
+- from dataclasses import dataclass, field
+- from pathlib import Path
+- from typing import Dict, List
+### 3. Classes 🏛️
+
+- `EloRegistry`: Persistent registry of Elo ratings for agents.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_evaluation_evaluate.md
+++ b/docs/component_audit/keisei_evaluation_evaluate.md
@@ -1,0 +1,132 @@
+# Software Documentation Template for Subsystems - evaluate
+
+## 📘 evaluate.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/evaluation/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+evaluate.py: Main script for evaluating PPO Shogi agents.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import argparse
+- import os
+- import random
+- from pathlib import Path
+- from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+- import numpy as np
+- import torch
+- from dotenv import load_dotenv  # type: ignore
+- import wandb  # Ensure wandb is imported for W&B logging
+- from keisei.core.ppo_agent import PPOAgent
+- from keisei.evaluation.loop import ResultsDict, run_evaluation_loop
+- from keisei.utils import BaseOpponent, EvaluationLogger, PolicyOutputMapper
+- from keisei.evaluation.elo_registry import EloRegistry
+- from keisei.utils.agent_loading import initialize_opponent, load_evaluation_agent
+- from keisei.utils.utils import load_config
+- from keisei.utils.unified_logger import (
+### 3. Classes 🏛️
+
+- `Evaluator`: Evaluator class encapsulates the evaluation logic for PPO Shogi agents.
+### 4. Functions/Methods ⚙️
+
+- `execute_full_evaluation_run`: Legacy-compatible wrapper for Evaluator class. Runs a full evaluation and returns the results dict.
+- `main_cli`: Entry point for CLI evaluation. This should parse arguments and call execute_full_evaluation_run.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_evaluation_loop.md
+++ b/docs/component_audit/keisei_evaluation_loop.md
@@ -1,0 +1,119 @@
+# Software Documentation Template for Subsystems - loop
+
+## 📘 loop.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/evaluation/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+loop.py: Core evaluation loop for PPO Shogi agents.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import Optional, TypedDict, Union
+- from keisei.core.ppo_agent import PPOAgent
+- from keisei.shogi.shogi_core_definitions import MoveTuple
+- from keisei.utils import BaseOpponent, EvaluationLogger, PolicyOutputMapper
+### 3. Classes 🏛️
+
+- `ResultsDict`: No docstring
+### 4. Functions/Methods ⚙️
+
+- `run_evaluation_loop`: No docstring
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_shogi___init__.md
+++ b/docs/component_audit/keisei_shogi___init__.md
@@ -1,0 +1,117 @@
+# Software Documentation Template for Subsystems - __init__
+
+## 📘 __init__.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/shogi/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Shogi Module - Japanese Chess game engine and related components.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from .shogi_core_definitions import Color, MoveTuple, Piece, PieceType
+- from .shogi_game import ShogiGame
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_shogi_features.md
+++ b/docs/component_audit/keisei_shogi_features.md
@@ -1,0 +1,125 @@
+# Software Documentation Template for Subsystems - features
+
+## 📘 features.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/shogi/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+features.py: FeatureSpec registry and core46 observation builder for Keisei Shogi.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import Callable, Dict
+- import numpy as np
+- from ..constants import MOVE_COUNT_NORMALIZATION_FACTOR
+### 3. Classes 🏛️
+
+- `FeatureSpec`: Describes a set of feature planes for Shogi observation tensors.
+### 4. Functions/Methods ⚙️
+
+- `register_feature`: No docstring
+- `build_core46`: Build the standard 46-plane observation tensor for the given game state.
+- `add_check_plane`: No docstring
+- `add_repetition_plane`: No docstring
+- `add_prom_zone_plane`: No docstring
+- `add_last2ply_plane`: No docstring
+- `add_hand_onehot_plane`: No docstring
+- `build_core46_all`: No docstring
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_shogi_shogi_core_definitions.md
+++ b/docs/component_audit/keisei_shogi_shogi_core_definitions.md
@@ -1,0 +1,121 @@
+# Software Documentation Template for Subsystems - shogi_core_definitions
+
+## 📘 shogi_core_definitions.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/shogi/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+shogi_core_definitions.py: Core type definitions, enums, constants,
+### 2. Modules 📦
+
+* **Dependencies:**
+- from enum import Enum
+- from typing import Dict, List, Optional, Set, Tuple, Union
+### 3. Classes 🏛️
+
+- `Color`: Represents the player color.
+- `PieceType`: Represents the type of a Shogi piece, including promoted states.
+- `TerminationReason`: Enumerates reasons why a Shogi game might terminate.
+- `Piece`: Represents a single Shogi piece.
+### 4. Functions/Methods ⚙️
+
+- `get_unpromoted_types`: Returns a list of all PieceType enums that represent unpromoted pieces
+- `get_piece_type_from_symbol`: Converts a piece symbol string (e.g., "P", "+R", "p", "+r") to a PieceType enum.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_shogi_shogi_engine.md
+++ b/docs/component_audit/keisei_shogi_shogi_engine.md
@@ -1,0 +1,117 @@
+# Software Documentation Template for Subsystems - shogi_engine
+
+## 📘 shogi_engine.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/shogi/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+This module re-exports the main classes from the refactored Shogi engine components
+### 2. Modules 📦
+
+* **Dependencies:**
+- from .shogi_core_definitions import Color, MoveTuple, Piece, PieceType
+- from .shogi_game import ShogiGame
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_shogi_shogi_game.md
+++ b/docs/component_audit/keisei_shogi_shogi_game.md
@@ -1,0 +1,127 @@
+# Software Documentation Template for Subsystems - shogi_game
+
+## 📘 shogi_game.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/shogi/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+shogi_game.py: Main ShogiGame class for DRL Shogi Client.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import copy  # Added for __deepcopy__
+- import logging
+- import re  # Added for SFEN parsing
+- from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+- import numpy as np
+- from . import shogi_game_io, shogi_move_execution, shogi_rules_logic
+- from .shogi_core_definitions import BASE_TO_PROMOTED_TYPE  # For SFEN deserialization
+- from .shogi_core_definitions import PIECE_TYPE_TO_HAND_TYPE  # Used in add_to_hand
+- from .shogi_core_definitions import PROMOTED_TYPES_SET  # For SFEN serialization
+- from .shogi_core_definitions import SYMBOL_TO_PIECE_TYPE  # Added for SFEN parsing
+- from .shogi_core_definitions import MoveTuple  # Already imported above
+- from .shogi_core_definitions import (
+### 3. Classes 🏛️
+
+- `ShogiGame`: Represents the Shogi game state, board, and operations.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_shogi_shogi_game_io.md
+++ b/docs/component_audit/keisei_shogi_shogi_game_io.md
@@ -1,0 +1,127 @@
+# Software Documentation Template for Subsystems - shogi_game_io
+
+## 📘 shogi_game_io.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/shogi/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+No docstring found—please add a summary
+### 2. Modules 📦
+
+* **Dependencies:**
+- import datetime  # For KIF Date header
+- import os
+- import re  # Import the re module
+- import sys
+- from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+- import numpy as np
+- from .shogi_core_definitions import (  # Observation plane constants
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `generate_neural_network_observation`: Returns the current board state as a (Channels, 9, 9) NumPy array for RL input.
+- `convert_game_to_text_representation`: Returns a string representation of the Shogi game board and state.
+- `game_to_kif`: Converts a game to a KIF file or string representation.
+- `_parse_sfen_square`: Converts an SFEN square string (e.g., "7g", "5e") to 0-indexed (row, col).
+- `_get_piece_type_from_sfen_char`: Converts an SFEN piece character (e.g., 'P', 'L', 'B') to a PieceType enum.
+- `sfen_to_move_tuple`: Parses an SFEN move string (e.g., "7g7f", "P*5e", "2b3a+")
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+- Line 433: # TODO: Consider adding kif_to_game and sfen_to_game functions if needed.

--- a/docs/component_audit/keisei_shogi_shogi_move_execution.md
+++ b/docs/component_audit/keisei_shogi_shogi_move_execution.md
@@ -1,0 +1,120 @@
+# Software Documentation Template for Subsystems - shogi_move_execution
+
+## 📘 shogi_move_execution.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/shogi/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Contains functions for applying and reverting moves in the Shogi game.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import (
+- from . import shogi_rules_logic
+- from .shogi_core_definitions import PROMOTED_TO_BASE_TYPE  # Added PROMOTED_TO_BASE_TYPE
+- from .shogi_core_definitions import (
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `apply_move_to_board`: Updates the game state after a move has been applied to the board by ShogiGame.make_move.
+- `revert_last_applied_move`: Reverts the last move made in the game, completely restoring the previous state.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_shogi_shogi_rules_logic.md
+++ b/docs/component_audit/keisei_shogi_shogi_rules_logic.md
@@ -1,0 +1,129 @@
+# Software Documentation Template for Subsystems - shogi_rules_logic
+
+## 📘 shogi_rules_logic.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/shogi/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Core Shogi game rules, move generation, and validation logic.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import TYPE_CHECKING, List, Optional, Set, Tuple  # Added Set
+- from .shogi_core_definitions import (
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `find_king`: Finds the king of the specified color on the board.
+- `is_in_check`: Checks if the king of 'player_color' is in check.
+- `is_piece_type_sliding`: Returns True if the piece type is a sliding piece (Lance, Bishop, Rook or their promoted versions).
+- `generate_piece_potential_moves`: Returns a list of (r_to, c_to) tuples for a piece, considering its
+- `check_for_nifu`: Checks for two unpromoted pawns of the same color on the given file.
+- `check_if_square_is_attacked`: Checks if the square (r_target, c_target) is attacked by any piece of attacker_color.
+- `check_for_uchi_fu_zume`: Returns True if dropping a pawn at (drop_row, drop_col) by 'color'
+- `is_king_in_check_after_simulated_move`: Checks if the king of 'player_color' is in check on the current board.
+- `can_promote_specific_piece`: Checks if a piece *can* be promoted given its type and move.
+- `must_promote_specific_piece`: Checks if a piece *must* promote when moving to r_to.
+- `can_drop_specific_piece`: Checks if a specific piece_type can be legally dropped by 'color' at (r_to, c_to).
+- `generate_all_legal_moves`: No docstring
+- `check_for_sennichite`: Returns True if the current board state has occurred four times (Sennichite).
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training___init__.md
+++ b/docs/component_audit/keisei_training___init__.md
@@ -1,0 +1,116 @@
+# Software Documentation Template for Subsystems - __init__
+
+## 📘 __init__.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+No docstring found—please add a summary
+### 2. Modules 📦
+
+* **Dependencies:**
+*None*
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_adaptive_display.md
+++ b/docs/component_audit/keisei_training_adaptive_display.md
@@ -1,0 +1,122 @@
+# Software Documentation Template for Subsystems - adaptive_display
+
+## 📘 adaptive_display.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Helpers for choosing training display layouts based on terminal size.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from __future__ import annotations
+- import os
+- from dataclasses import dataclass
+- from typing import Tuple
+- from rich.console import Console
+- from keisei.config_schema import DisplayConfig
+### 3. Classes 🏛️
+
+- `TerminalInfo`: No docstring
+- `AdaptiveDisplayManager`: Determine which layout variant should be used for the training TUI.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_callback_manager.md
+++ b/docs/component_audit/keisei_training_callback_manager.md
@@ -1,0 +1,117 @@
+# Software Documentation Template for Subsystems - callback_manager
+
+## 📘 callback_manager.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+training/callback_manager.py: Manages training callbacks and their execution.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import TYPE_CHECKING, Any, List
+- from . import callbacks
+### 3. Classes 🏛️
+
+- `CallbackManager`: Manages the setup and execution of training callbacks.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_callbacks.md
+++ b/docs/component_audit/keisei_training_callbacks.md
@@ -1,0 +1,120 @@
+# Software Documentation Template for Subsystems - callbacks
+
+## 📘 callbacks.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+training/callbacks.py: Periodic task callbacks for the Shogi RL trainer.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import os
+- from abc import ABC
+- from typing import TYPE_CHECKING
+### 3. Classes 🏛️
+
+- `Callback`: No docstring
+- `CheckpointCallback`: No docstring
+- `EvaluationCallback`: No docstring
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_compatibility_mixin.md
+++ b/docs/component_audit/keisei_training_compatibility_mixin.md
@@ -1,0 +1,117 @@
+# Software Documentation Template for Subsystems - compatibility_mixin
+
+## 📘 compatibility_mixin.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+compatibility_mixin.py: Provides backward compatibility properties and methods for the Trainer class.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import os
+- from typing import Any, Callable, Dict, List, Optional
+### 3. Classes 🏛️
+
+- `CompatibilityMixin`: Mixin class providing backward compatibility properties and methods.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_display.md
+++ b/docs/component_audit/keisei_training_display.md
@@ -1,0 +1,125 @@
+# Software Documentation Template for Subsystems - display
+
+## 📘 display.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+training/display.py: Rich UI management for the Shogi RL trainer.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import List, Union, Optional
+- from rich.console import Console, Group
+- from rich.layout import Layout
+- from rich.live import Live
+- from rich.panel import Panel
+- from rich.progress import (
+- from rich.text import Text
+- from keisei.config_schema import DisplayConfig
+- from .display_components import ShogiBoard, Sparkline
+- from .adaptive_display import AdaptiveDisplayManager
+### 3. Classes 🏛️
+
+- `TrainingDisplay`: No docstring
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_display_components.md
+++ b/docs/component_audit/keisei_training_display_components.md
@@ -1,0 +1,123 @@
+# Software Documentation Template for Subsystems - display_components
+
+## 📘 display_components.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Reusable Rich display components for the training TUI.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from __future__ import annotations
+- from typing import Protocol, Optional, List, Sequence
+- from keisei.utils.unified_logger import log_error_to_stderr
+- from rich.console import RenderableType, Group
+- from rich.panel import Panel
+- from rich.text import Text
+### 3. Classes 🏛️
+
+- `DisplayComponent`: Protocol for display components used by :class:`TrainingDisplay`.
+- `ShogiBoard`: ASCII representation of the current Shogi board state.
+- `Sparkline`: Simple Unicode sparkline generator for metric trends.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_display_manager.md
+++ b/docs/component_audit/keisei_training_display_manager.md
@@ -1,0 +1,121 @@
+# Software Documentation Template for Subsystems - display_manager
+
+## 📘 display_manager.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+training/display_manager.py: Manages Rich UI display components and logging.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import sys
+- from typing import Any, List, Optional
+- from rich.console import Console, Text
+- from rich.live import Live
+- from keisei.utils.unified_logger import log_error_to_stderr
+- from . import display
+### 3. Classes 🏛️
+
+- `DisplayManager`: Manages Rich console display, logging, and UI components.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_elo_rating.md
+++ b/docs/component_audit/keisei_training_elo_rating.md
@@ -1,0 +1,118 @@
+# Software Documentation Template for Subsystems - elo_rating
+
+## 📘 elo_rating.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Elo rating calculation utility for training progress.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from __future__ import annotations
+- from typing import Dict, List, Optional
+- from keisei.shogi.shogi_core_definitions import Color
+### 3. Classes 🏛️
+
+- `EloRatingSystem`: Maintain Elo ratings for black and white players.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_env_manager.md
+++ b/docs/component_audit/keisei_training_env_manager.md
@@ -1,0 +1,121 @@
+# Software Documentation Template for Subsystems - env_manager
+
+## 📘 env_manager.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+training/env_manager.py: Environment management for Shogi RL training.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import sys
+- from typing import Any, Callable, Optional, Tuple  # Added Optional
+- import numpy as np  # Added for type hinting
+- from keisei.config_schema import AppConfig
+- from keisei.shogi import ShogiGame
+- from keisei.utils import PolicyOutputMapper
+### 3. Classes 🏛️
+
+- `EnvManager`: Manages environment setup and configuration for training runs.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_metrics_manager.md
+++ b/docs/component_audit/keisei_training_metrics_manager.md
@@ -1,0 +1,122 @@
+# Software Documentation Template for Subsystems - metrics_manager
+
+## 📘 metrics_manager.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+metrics_manager.py: Manages training statistics, metrics tracking, and formatting.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import json
+- from dataclasses import dataclass
+- from typing import Any, Dict, Optional, Tuple, List
+- from keisei.shogi.shogi_core_definitions import Color
+- from .elo_rating import EloRatingSystem
+### 3. Classes 🏛️
+
+- `TrainingStats`: Container for training statistics.
+- `MetricsHistory`: Track historical metrics required for trend visualisation and Elo.
+- `MetricsManager`: Manages training statistics, PPO metrics formatting, and progress tracking.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_model_manager.md
+++ b/docs/component_audit/keisei_training_model_manager.md
@@ -1,0 +1,128 @@
+# Software Documentation Template for Subsystems - model_manager
+
+## 📘 model_manager.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+training/model_manager.py: Model lifecycle management for Shogi RL training.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import os
+- import shutil
+- import time
+- from typing import Any, Dict, List, Optional, Tuple
+- import torch
+- from torch.cuda.amp import GradScaler
+- import wandb
+- from keisei.config_schema import AppConfig
+- from keisei.core.actor_critic_protocol import ActorCriticProtocol
+- from keisei.core.ppo_agent import PPOAgent
+- from keisei.shogi import features
+- from keisei.training.models import model_factory
+- from . import utils
+### 3. Classes 🏛️
+
+- `ModelManager`: Manages model lifecycle for training runs.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_models___init__.md
+++ b/docs/component_audit/keisei_training_models___init__.md
@@ -1,0 +1,117 @@
+# Software Documentation Template for Subsystems - __init__
+
+## 📘 __init__.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/models/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+No docstring found—please add a summary
+### 2. Modules 📦
+
+* **Dependencies:**
+- from keisei.core.actor_critic_protocol import ActorCriticProtocol
+- from .resnet_tower import ActorCriticResTower
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `model_factory`: No docstring
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_models_resnet_tower.md
+++ b/docs/component_audit/keisei_training_models_resnet_tower.md
@@ -1,0 +1,122 @@
+# Software Documentation Template for Subsystems - resnet_tower
+
+## 📘 resnet_tower.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/models/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+resnet_tower.py: ActorCriticResTower model for Keisei Shogi with SE block support.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import Optional
+- import torch
+- import torch.nn as nn
+- import torch.nn.functional as F
+- from keisei.core.base_actor_critic import BaseActorCriticModel
+### 3. Classes 🏛️
+
+- `SqueezeExcitation`: No docstring
+- `ResidualBlock`: No docstring
+- `ActorCriticResTower`: No docstring
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_parallel___init__.md
+++ b/docs/component_audit/keisei_training_parallel___init__.md
@@ -1,0 +1,120 @@
+# Software Documentation Template for Subsystems - __init__
+
+## 📘 __init__.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Parallel training system for Keisei Shogi.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from .communication import WorkerCommunicator
+- from .model_sync import ModelSynchronizer
+- from .parallel_manager import ParallelManager
+- from .self_play_worker import SelfPlayWorker
+- from .utils import compress_array, decompress_array
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_parallel_communication.md
+++ b/docs/component_audit/keisei_training_parallel_communication.md
@@ -1,0 +1,123 @@
+# Software Documentation Template for Subsystems - communication
+
+## 📘 communication.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Communication utilities for parallel training workers.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import logging
+- import multiprocessing as mp
+- import queue
+- import time
+- from typing import Any, Dict, List, Optional, Tuple
+- import numpy as np
+- import torch
+- from .utils import compress_array
+### 3. Classes 🏛️
+
+- `WorkerCommunicator`: Manages communication between main training process and worker processes.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_parallel_model_sync.md
+++ b/docs/component_audit/keisei_training_parallel_model_sync.md
@@ -1,0 +1,124 @@
+# Software Documentation Template for Subsystems - model_sync
+
+## 📘 model_sync.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Model synchronization utilities for parallel training.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import gzip
+- import logging
+- import pickle
+- import time
+- from typing import Any, Dict
+- import numpy as np
+- import torch
+- import torch.nn as nn
+- from .utils import compress_array, decompress_array
+### 3. Classes 🏛️
+
+- `ModelSynchronizer`: Manages synchronization of model weights between main process and workers.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_parallel_parallel_manager.md
+++ b/docs/component_audit/keisei_training_parallel_parallel_manager.md
@@ -1,0 +1,124 @@
+# Software Documentation Template for Subsystems - parallel_manager
+
+## 📘 parallel_manager.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Parallel training manager for coordinating multiple self-play workers.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import logging
+- import time
+- from typing import Any, Dict, List
+- import torch
+- import torch.nn as nn
+- from keisei.core.experience_buffer import ExperienceBuffer
+- from keisei.training.parallel.communication import WorkerCommunicator
+- from keisei.training.parallel.model_sync import ModelSynchronizer
+- from keisei.training.parallel.self_play_worker import SelfPlayWorker
+### 3. Classes 🏛️
+
+- `ParallelManager`: Manages parallel experience collection using multiple worker processes.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_parallel_self_play_worker.md
+++ b/docs/component_audit/keisei_training_parallel_self_play_worker.md
@@ -1,0 +1,127 @@
+# Software Documentation Template for Subsystems - self_play_worker
+
+## 📘 self_play_worker.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Self-play worker process for parallel experience collection.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import logging
+- import multiprocessing as mp
+- import queue
+- import time
+- from typing import Any, Dict, List, Optional
+- import numpy as np
+- import torch
+- from .utils import decompress_array
+- from keisei.core.actor_critic_protocol import ActorCriticProtocol
+- from keisei.core.experience_buffer import Experience
+- from keisei.shogi.shogi_game import ShogiGame
+- from keisei.utils.utils import PolicyOutputMapper
+### 3. Classes 🏛️
+
+- `SelfPlayWorker`: Worker process for parallel self-play experience collection.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_parallel_utils.md
+++ b/docs/component_audit/keisei_training_parallel_utils.md
@@ -1,0 +1,120 @@
+# Software Documentation Template for Subsystems - utils
+
+## 📘 utils.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/parallel/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+No docstring found—please add a summary
+### 2. Modules 📦
+
+* **Dependencies:**
+- import gzip
+- import logging
+- from typing import Any, Dict
+- import numpy as np
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `compress_array`: Compress a numpy array with gzip for transmission.
+- `decompress_array`: Decompress array data produced by :func:`compress_array`.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_session_manager.md
+++ b/docs/component_audit/keisei_training_session_manager.md
@@ -1,0 +1,124 @@
+# Software Documentation Template for Subsystems - session_manager
+
+## 📘 session_manager.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+training/session_manager.py: Session lifecycle management for Shogi RL training.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import os
+- import sys
+- from datetime import datetime
+- from typing import Any, Callable, Dict, Optional
+- import wandb
+- from keisei.config_schema import AppConfig
+- from keisei.utils.unified_logger import log_error_to_stderr, log_warning_to_stderr
+- from keisei.utils.utils import generate_run_name
+- from . import utils
+### 3. Classes 🏛️
+
+- `SessionManager`: Manages session-level lifecycle for training runs.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_setup_manager.md
+++ b/docs/component_audit/keisei_training_setup_manager.md
@@ -1,0 +1,126 @@
+# Software Documentation Template for Subsystems - setup_manager
+
+## 📘 setup_manager.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+setup_manager.py: Handles complex initialization and setup logic for the Trainer class.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import sys
+- from datetime import datetime
+- from typing import Any, Optional, Tuple
+- import torch
+- from keisei.config_schema import AppConfig
+- from keisei.core.actor_critic_protocol import ActorCriticProtocol
+- from keisei.core.experience_buffer import ExperienceBuffer
+- from keisei.core.ppo_agent import PPOAgent
+- from keisei.utils import TrainingLogger
+- from keisei.utils.unified_logger import log_error_to_stderr
+- from .step_manager import StepManager
+### 3. Classes 🏛️
+
+- `SetupManager`: Manages the complex setup and initialization logic for training components.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_step_manager.md
+++ b/docs/component_audit/keisei_training_step_manager.md
@@ -1,0 +1,127 @@
+# Software Documentation Template for Subsystems - step_manager
+
+## 📘 step_manager.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+step_manager.py: Manages individual training steps and episode lifecycle.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import time  # Added import
+- from dataclasses import dataclass
+- from typing import Any, Callable, Dict, List, Optional, Tuple
+- import numpy as np  # Added import
+- import torch  # Added import
+- from keisei.config_schema import AppConfig
+- from keisei.core.experience_buffer import ExperienceBuffer
+- from keisei.core.ppo_agent import PPOAgent
+- from keisei.shogi import Color, ShogiGame  # Added Color import
+- from keisei.utils import PolicyOutputMapper, format_move_with_description_enhanced
+### 3. Classes 🏛️
+
+- `EpisodeState`: Represents the current state of a training episode.
+- `StepResult`: Result of executing a single training step.
+- `StepManager`: Manages individual training step execution and episode lifecycle.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_train.md
+++ b/docs/component_audit/keisei_training_train.md
@@ -1,0 +1,123 @@
+# Software Documentation Template for Subsystems - train
+
+## 📘 train.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Main training script for Keisei Shogi RL agent.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import argparse
+- import multiprocessing
+- import sys
+- from keisei.config_schema import AppConfig
+- from keisei.utils import load_config
+- from keisei.utils.unified_logger import log_error_to_stderr, log_info_to_stderr
+- from .trainer import Trainer
+- from .utils import apply_wandb_sweep_config, build_cli_overrides
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `main`: Main entry point for the training script (Pydantic config version).
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_train_wandb_sweep.md
+++ b/docs/component_audit/keisei_training_train_wandb_sweep.md
@@ -1,0 +1,123 @@
+# Software Documentation Template for Subsystems - train_wandb_sweep
+
+## 📘 train_wandb_sweep.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+W&B Sweep-enabled training script for Keisei Shogi RL agent.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import argparse
+- import multiprocessing
+- import sys
+- from keisei.config_schema import AppConfig
+- from keisei.training.trainer import Trainer
+- from keisei.training.utils import apply_wandb_sweep_config, build_cli_overrides
+- from keisei.utils import load_config
+- from keisei.utils.unified_logger import log_error_to_stderr
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `main`: Main entry point for the W&B sweep-enabled training script.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_trainer.md
+++ b/docs/component_audit/keisei_training_trainer.md
@@ -1,0 +1,135 @@
+# Software Documentation Template for Subsystems - trainer
+
+## 📘 trainer.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+trainer.py: Contains the Trainer class for managing the Shogi RL training loop (refactored).
+### 2. Modules 📦
+
+* **Dependencies:**
+- from datetime import datetime
+- from typing import Any, Callable, Dict, Optional
+- import torch
+- import wandb
+- from keisei.config_schema import AppConfig
+- from keisei.core.actor_critic_protocol import ActorCriticProtocol
+- from keisei.core.experience_buffer import ExperienceBuffer
+- from keisei.core.ppo_agent import PPOAgent
+- from keisei.evaluation.evaluate import execute_full_evaluation_run
+- from keisei.utils import TrainingLogger
+- from .callback_manager import CallbackManager
+- from .compatibility_mixin import CompatibilityMixin
+- from .display_manager import DisplayManager
+- from .env_manager import EnvManager
+- from .metrics_manager import MetricsManager
+- from .model_manager import ModelManager
+- from .session_manager import SessionManager
+- from .setup_manager import SetupManager
+- from .step_manager import EpisodeState, StepManager
+- from .training_loop_manager import TrainingLoopManager
+### 3. Classes 🏛️
+
+- `Trainer`: Manages the training process for the PPO Shogi agent.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_training_loop_manager.md
+++ b/docs/component_audit/keisei_training_training_loop_manager.md
@@ -1,0 +1,120 @@
+# Software Documentation Template for Subsystems - training_loop_manager
+
+## 📘 training_loop_manager.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Manages the main training loop execution, previously part of the Trainer class.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import time
+- from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+- import torch.nn as nn
+- from keisei.shogi.shogi_core_definitions import Color
+- from keisei.utils.unified_logger import log_info_to_stderr
+### 3. Classes 🏛️
+
+- `TrainingLoopManager`: Manages the primary iteration logic of the training loop.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_training_utils.md
+++ b/docs/component_audit/keisei_training_utils.md
@@ -1,0 +1,134 @@
+# Software Documentation Template for Subsystems - utils
+
+## 📘 utils.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/training/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+training/utils.py: Helper functions for setup and configuration in the Shogi RL trainer.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import glob
+- import json
+- import os
+- import pickle
+- import random
+- import sys
+- from typing import Optional
+- import numpy as np
+- import torch
+- import wandb
+- from keisei.config_schema import AppConfig
+- from keisei.utils.unified_logger import log_error_to_stderr, log_info_to_stderr
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `_validate_checkpoint`: Validate checkpoint file integrity by attempting to load it.
+- `find_latest_checkpoint`: No docstring
+- `serialize_config`: Serialize AppConfig to JSON string using Pydantic's built-in serialization.
+- `setup_directories`: No docstring
+- `setup_seeding`: No docstring
+- `setup_wandb`: No docstring
+- `apply_wandb_sweep_config`: Apply W&B sweep configuration to override parameters.
+- `build_cli_overrides`: Build configuration overrides from command line arguments.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_utils___init__.md
+++ b/docs/component_audit/keisei_utils___init__.md
@@ -1,0 +1,118 @@
+# Software Documentation Template for Subsystems - __init__
+
+## 📘 __init__.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/utils/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+No docstring found—please add a summary
+### 2. Modules 📦
+
+* **Dependencies:**
+- from . import agent_loading, opponents
+- from .move_formatting import (
+- from .utils import (
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_utils_agent_loading.md
+++ b/docs/component_audit/keisei_utils_agent_loading.md
@@ -1,0 +1,121 @@
+# Software Documentation Template for Subsystems - agent_loading
+
+## 📘 agent_loading.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/utils/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+agent_loading.py: Utilities for loading PPO agents and initializing opponents.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import os
+- from typing import Any, Optional
+- from keisei.config_schema import AppConfig, EnvConfig, ParallelConfig, TrainingConfig
+- from keisei.utils.opponents import (
+- from keisei.utils.unified_logger import log_error_to_stderr, log_info_to_stderr
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `load_evaluation_agent`: No docstring
+- `initialize_opponent`: No docstring
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_utils_checkpoint.md
+++ b/docs/component_audit/keisei_utils_checkpoint.md
@@ -1,0 +1,118 @@
+# Software Documentation Template for Subsystems - checkpoint
+
+## 📘 checkpoint.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/utils/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+checkpoint.py: Model checkpoint migration and compatibility utilities for Keisei Shogi.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from typing import Any, Dict
+- import torch
+- import torch.nn as nn
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `load_checkpoint_with_padding`: Loads a checkpoint into the model, zero-padding the first conv layer if input channels have increased.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_utils_move_formatting.md
+++ b/docs/component_audit/keisei_utils_move_formatting.md
@@ -1,0 +1,119 @@
+# Software Documentation Template for Subsystems - move_formatting
+
+## 📘 move_formatting.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/utils/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+move_formatting.py: Contains utilities for formatting Shogi moves.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from keisei.shogi.shogi_core_definitions import PieceType
+### 3. Classes 🏛️
+
+*None*
+### 4. Functions/Methods ⚙️
+
+- `format_move_with_description`: Formats a shogi move with USI notation and English description.
+- `format_move_with_description_enhanced`: Enhanced move formatting that takes piece info as parameter for better demo logging.
+- `_get_piece_name`: Convert PieceType enum to Japanese name with English translation.
+- `_coords_to_square_name`: Convert 0-indexed coordinates to square name like '7f'.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_utils_opponents.md
+++ b/docs/component_audit/keisei_utils_opponents.md
@@ -1,0 +1,121 @@
+# Software Documentation Template for Subsystems - opponents
+
+## 📘 opponents.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/utils/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+opponents.py: Contains simple opponent classes for evaluation and testing.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import random
+- from typing import List
+- from keisei.shogi.shogi_core_definitions import MoveTuple, PieceType
+- from keisei.shogi.shogi_game import ShogiGame
+- from keisei.utils.utils import BaseOpponent
+### 3. Classes 🏛️
+
+- `SimpleRandomOpponent`: An opponent that selects a random legal move.
+- `SimpleHeuristicOpponent`: An opponent that uses simple heuristics to select a move.
+### 4. Functions/Methods ⚙️
+
+*None*
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_utils_profiling.md
+++ b/docs/component_audit/keisei_utils_profiling.md
@@ -1,0 +1,131 @@
+# Software Documentation Template for Subsystems - profiling
+
+## 📘 profiling.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/utils/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+Development profiling helpers for performance monitoring.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import cProfile
+- import functools
+- import io
+- import logging
+- import pstats
+- import time
+- from contextlib import contextmanager
+- from typing import Any, Callable, Dict
+- from keisei.utils.unified_logger import log_info_to_stderr
+### 3. Classes 🏛️
+
+- `_FastTimerContext`: Fast timer context with minimal overhead.
+- `PerformanceMonitor`: Simple performance monitoring for development.
+### 4. Functions/Methods ⚙️
+
+- `profile_function`: Decorator to profile a function's execution time.
+- `profile_code_block`: Context manager to profile a code block.
+- `run_profiler`: Run a function with cProfile and return results.
+- `profile_training_step`: Decorator specifically for profiling training steps.
+- `profile_game_operation`: Decorator for profiling game operations (moves, evaluations, etc.).
+- `memory_usage_mb`: Get current memory usage in MB.
+- `example_usage`: Example usage of profiling utilities.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_utils_unified_logger.md
+++ b/docs/component_audit/keisei_utils_unified_logger.md
@@ -1,0 +1,123 @@
+# Software Documentation Template for Subsystems - unified_logger
+
+## 📘 unified_logger.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/utils/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+unified_logger.py: Unified logging infrastructure for consistent logging across the codebase.
+### 2. Modules 📦
+
+* **Dependencies:**
+- import sys
+- from datetime import datetime
+- from typing import Any, Optional
+- from rich.console import Console
+- from rich.text import Text
+### 3. Classes 🏛️
+
+- `UnifiedLogger`: A unified logging interface that provides consistent logging across the codebase.
+### 4. Functions/Methods ⚙️
+
+- `create_module_logger`: Create a logger for a specific module.
+- `log_error_to_stderr`: Utility function for consistent error logging to stderr.
+- `log_warning_to_stderr`: Utility function for consistent warning logging to stderr.
+- `log_info_to_stderr`: Utility function for consistent info logging to stderr.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/docs/component_audit/keisei_utils_utils.md
+++ b/docs/component_audit/keisei_utils_utils.md
@@ -1,0 +1,138 @@
+# Software Documentation Template for Subsystems - utils
+
+## 📘 utils.py as of 2025-06-05
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `/keisei/utils/`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-05`
+**Responsible Author or Agent ID:** `GitHub Copilot`
+
+---
+
+### 1. Overview 📜
+
+utils.py: Contains PolicyOutputMapper and TrainingLogger.
+### 2. Modules 📦
+
+* **Dependencies:**
+- from __future__ import annotations
+- import datetime
+- import json
+- import logging
+- import os
+- import sys
+- from abc import ABC, abstractmethod
+- from typing import (
+- import torch
+- import yaml
+- from pydantic import ValidationError
+- from rich.console import Console
+- from rich.text import Text
+- from keisei.config_schema import AppConfig
+- from keisei.shogi.shogi_core_definitions import (
+- from keisei.utils.unified_logger import log_error_to_stderr
+### 3. Classes 🏛️
+
+- `BaseOpponent`: Abstract base class for game opponents.
+- `PolicyOutputMapper`: Maps Shogi moves to/from policy network output indices.
+- `TrainingLogger`: Handles logging of training progress to a file and optionally to stdout.
+- `EvaluationLogger`: Handles logging of evaluation results to a file and optionally to stdout.
+### 4. Functions/Methods ⚙️
+
+- `_load_yaml_or_json`: No docstring
+- `_merge_overrides`: No docstring
+- `_map_flat_overrides`: No docstring
+- `load_config`: Loads configuration from a YAML or JSON file and applies CLI overrides.
+- `generate_run_name`: Generates a unique run name based on config and timestamp, or returns the provided run_name if set.
+### 5. Shared or Complex Data Structures 📊
+
+* **Structure Name:** `[e.g., TrainingConfigDict]`
+
+  * **Type:** `[e.g., Dict[str, Any]]`
+  * **Purpose:** What the structure is meant to hold.
+  * **Format:** JSON schema, class, pydantic model, dataclass, etc.
+  * **Fields:**
+
+    * `learning_rate: float – Training LR (default 0.001)`
+    * `env_name: str – Environment name, must be Gym-compliant`
+  * **Validation Constraints:** (Optional)
+  * **Used In:** List of modules/classes/functions using this.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  Visual or list representation of module relationships:
+
+  ```
+  training_orchestrator.py
+    ├── uses → model_factory.py
+    ├── uses → replay_buffer.py
+  model_factory.py
+    └── uses → architectures/
+  ```
+
+* **Cross-Folder Imports:**
+
+  * `[From ../agents]: imports BaseAgent, PPOAgent`
+  * `[To /shogi/]: calls validate_board_state()`
+
+* **Data Flow Summary:**
+
+  * Describe the flow of data (esp. structured or recurring payloads).
+  * Clarify transformation stages (e.g., raw → validated → batched → logged)
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:**
+  Targets or expectations (latency, throughput, memory usage)
+
+* **Security:**
+  Input sanitisation, secrets handling, any interfaces that cross trust boundaries
+
+* **Error Handling & Logging:**
+  Global error handling strategy. Log levels used.
+
+* **Scalability Concerns:**
+  Horizontal scaling? Worker pool strategy? Resource contention?
+
+* **Testing & Instrumentation:**
+
+  * Test harness location: `[e.g. tests/test_training_orchestrator.py]`
+  * Fakes, mocks, or stubs used
+  * Metrics or tracing (e.g., OpenTelemetry, Prometheus)
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:**
+
+  * `TRAINING_CONFIG_PATH: str – Path to default config`
+  * `GPU_ENABLED: bool – Whether GPU usage is enabled`
+
+* **CLI Interfaces / Entry Points (if any):**
+
+  * `python -m training_orchestrator --config configs/dev.yaml`
+
+* **Config File Schema:**
+
+  * Reference if JSON/YAML schema is defined externally.
+  * Inline spec if useful.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **\[Term]:** `[Definition]`
+  *Include terms specific to the business logic, framework, or internal slang (e.g., “rollout,” “shard,” “trace span”).*
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+*No TODO/FIXME comments found*

--- a/scripts/sync_audit_docs.py
+++ b/scripts/sync_audit_docs.py
@@ -1,0 +1,129 @@
+import os
+import ast
+import datetime
+import re
+from pathlib import Path
+
+TEMPLATE_PATH = Path('docs/templates/SUBSYSTEM_TEMPLATE.md')
+OUTPUT_DIR = Path('docs/component_audit')
+
+with TEMPLATE_PATH.open('r', encoding='utf-8') as f:
+    TEMPLATE_TEXT = f.read()
+
+HEADER_PROJECT = 'Keisei - Deep Reinforcement Learning Shogi Client'
+HEADER_VERSION = '1.0'
+HEADER_AUTHOR = 'GitHub Copilot'
+
+def extract_info(py_path: Path):
+    source = py_path.read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    docstring = ast.get_docstring(tree)
+    missing_docstring = docstring is None
+    if docstring:
+        docstring = docstring.strip().splitlines()[0]
+    else:
+        docstring = 'No docstring found—please add a summary'
+
+    classes = []
+    functions = []
+    imports = []
+
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            doc = ast.get_docstring(node)
+            doc = doc.strip().splitlines()[0] if doc else 'No docstring'
+            classes.append((node.name, doc))
+        elif isinstance(node, ast.FunctionDef):
+            doc = ast.get_docstring(node)
+            doc = doc.strip().splitlines()[0] if doc else 'No docstring'
+            functions.append((node.name, doc))
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            line = source.splitlines()[node.lineno-1].strip()
+            imports.append(line)
+
+    todos = []
+    for i, line in enumerate(source.splitlines(), start=1):
+        if 'TODO' in line or 'FIXME' in line:
+            todos.append(f"Line {i}: {line.strip()}")
+
+    return {
+        'docstring': docstring,
+        'classes': classes,
+        'functions': functions,
+        'imports': imports,
+        'todos': todos,
+        'missing_docstring': missing_docstring,
+    }
+
+def replace_section(text: str, heading_pattern: str, new_content: str) -> str:
+    lines = text.splitlines()
+    start = None
+    for idx, line in enumerate(lines):
+        if re.match(heading_pattern, line):
+            start = idx
+            break
+    if start is None:
+        return text
+    end = len(lines)
+    for idx in range(start + 1, len(lines)):
+        if re.match(r'^### ', lines[idx]):
+            end = idx
+            break
+    new_lines = [lines[start], ''] + new_content.splitlines()
+    lines[start:end] = new_lines
+    return '\n'.join(lines)
+
+def build_doc(info, module_path: Path) -> str:
+    today = datetime.date.today().isoformat()
+    module_name = module_path.stem
+    folder_path = '/' + module_path.parent.as_posix() + '/'
+
+    text = TEMPLATE_TEXT
+    text = text.replace('[MODULE NAME]', module_name)
+    text = text.replace('[FILENAME]', module_path.name)
+    text = text.replace('[DATE]', today)
+    text = text.replace('[Insert Project Name]', HEADER_PROJECT)
+    text = text.replace('[Insert Full Folder Path]', folder_path)
+    text = text.replace('[Insert Version]', HEADER_VERSION)
+    text = text.replace('[Insert Date]', today)
+    text = text.replace('[Insert if applicable]', HEADER_AUTHOR)
+
+    overview = info['docstring']
+    classes = '\n'.join(f"- `{n}`: {d}" for n, d in info['classes']) or '*None*'
+    functions = '\n'.join(f"- `{n}`: {d}" for n, d in info['functions']) or '*None*'
+    imports = '\n'.join(f"- {l}" for l in info['imports']) or '*None*'
+    todos = '\n'.join(f"- {t}" for t in info['todos']) or '*No TODO/FIXME comments found*'
+
+    text = replace_section(text, r'^### 1\. Overview', overview)
+    text = replace_section(text, r'^### 3\. Classes', classes)
+    text = replace_section(text, r'^### 4\. Functions', functions)
+    text = replace_section(text, r'^### 2\. Modules', f"* **Dependencies:**\n{imports}")
+    text = replace_section(text, r'^### 10\. Known Issues', todos)
+
+    return text
+
+def main():
+    modules = sorted(Path('keisei').rglob('*.py'))
+    created = 0
+    overwritten = 0
+    warnings = []
+    for module in modules:
+        info = extract_info(module)
+        doc_path = OUTPUT_DIR / module.as_posix().replace('/', '_').replace('.py', '.md')
+        doc_text = build_doc(info, module)
+        if not doc_path.exists():
+            created += 1
+            action = 'Created'
+        else:
+            overwritten += 1
+            action = 'Overwrote'
+        doc_path.write_text(doc_text, encoding='utf-8')
+        print(f"[✓] {action} {doc_path}")
+        if info['missing_docstring']:
+            warnings.append(f"[!] Warning: {module} has no module docstring—insert 'No docstring found' placeholder.")
+    print(f"Processed {len(modules)} modules. Docs created: {created}, overwritten: {overwritten}.")
+    if warnings:
+        print('\n'.join(warnings))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a script to generate audit docs for all modules under `keisei/`
- prepopulate docs using `docs/templates/SUBSYSTEM_TEMPLATE.md`
- create audit docs for each module under `docs/component_audit/`

## Testing
- `pytest -q` *(failed: import errors / long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68417f3727a483239c7477175317143b