### PR TITLE
Fix Shogi board alignment with dynamic width

### DIFF
--- a/keisei/training/display_components.py
+++ b/keisei/training/display_components.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Protocol, Optional, List, Sequence
+from wcwidth import wcswidth
 
 from keisei.utils.unified_logger import log_error_to_stderr
 
@@ -54,10 +55,13 @@ class ShogiBoard:
 
     def _generate_ascii_board(self, board_state) -> str:
         lines: List[str] = ["  9 8 7 6 5 4 3 2 1"]
+        cell_width = 2 if self.use_unicode else 1
         for r_idx, row in enumerate(board_state.board):
             line_parts: List[str] = [f"{9 - r_idx} "]
             for piece in reversed(row):
-                line_parts.append(f"{self._piece_to_symbol(piece)} ")
+                symbol = self._piece_to_symbol(piece)
+                padding = max(0, cell_width - wcswidth(symbol))
+                line_parts.append(symbol + " " * (padding + 1))
             lines.append("".join(line_parts))
         return "\n".join(lines)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -67,4 +67,5 @@ psutil==6.1.0           # Useful for monitoring system resources during dev/test
 tomlkit==0.13.2         # For parsing pyproject.toml, used by black, pylint, etc.
 types-requests==2.32.0.20250515 # Type stubs
 types-tqdm==4.67.0.20250516     # Type stubs
+wcwidth==0.2.13              # Used to compute display widths in TUI
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,4 @@ pydantic_core==2.33.2 # Core for pydantic
 PyYAML==6.0.2 # For config file handling
 setproctitle==1.3.6 # For W&B
 six==1.17.0 # Compatibility library, often a dependency
+wcwidth==0.2.13 # Determine printable width of Unicode chars


### PR DESCRIPTION
## Summary
- pad Unicode Shogi board cells using `wcwidth`
- add `wcwidth` to dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418ea59c488323a949d2bf4dfed841