### PR TITLE
Add documentation for missing keisei modules

### DIFF
--- a/docs/component_audit/evaluation_elo_registry.md
+++ b/docs/component_audit/evaluation_elo_registry.md
@@ -1,0 +1,179 @@
+# Software Documentation Template for Subsystems - Elo Rating Registry
+
+## 📘 elo_registry.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `keisei/evaluation/elo_registry.py`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `Documentation Agent`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Provide persistent storage and update mechanics for Elo ratings of trained agents. Used during evaluation to track relative strength between models.
+* **Key Responsibilities:**
+  - Load and save Elo rating data from a JSON file
+  - Compute expected scores and update ratings from match results
+  - Expose helper to retrieve a model's current rating
+* **Domain Context:**
+  Part of the evaluation subsystem measuring competitive performance of PPO agents through standard Elo rating calculations.
+* **High-Level Architecture / Interaction Summary:**
+  Simple dataclass wrapper around a JSON file. The Evaluator instantiates `EloRegistry` to update ratings after evaluation games.
+
+---
+
+### 2. Modules 📦
+
+* **Module Name:** `elo_registry.py`
+  * **Purpose:** Maintain a JSON-backed mapping of model identifiers to Elo ratings.
+  * **Design Patterns Used:** Lightweight Repository pattern for persistence.
+  * **Key Functions/Classes Provided:**
+    - `EloRegistry` dataclass
+  * **Configuration Surface:**
+    - File path to registry JSON (`path` attribute)
+    - Default rating and K-factor constants
+  * **Dependencies:**
+    * **Internal:** None
+    * **External:** `json`, `pathlib.Path`, `dataclasses`
+  * **External API Contracts:** None – internal use only by evaluation workflow.
+  * **Side Effects / Lifecycle Considerations:** Reads and writes JSON file on disk via `load()` and `save()` methods.
+  * **Usage Examples:**
+    ```python
+    registry = EloRegistry(Path("elo.json"))
+    registry.update_ratings("agentA", "agentB", ["agent_win", "opponent_win"])
+    registry.save()
+    ```
+
+---
+
+### 3. Classes 🏛️
+
+* **Class Name:** `EloRegistry`
+  * **Defined In Module:** `elo_registry.py`
+  * **Purpose:** Persistently track Elo ratings for agents across evaluation runs.
+  * **Design Role:** Simple data repository with rating update logic.
+  * **Inheritance:**
+    * **Extends:** `object` via `dataclass`
+    * **Subclasses:** None
+  * **Key Attributes/Properties:**
+    - `path: Path` – Filesystem location of the JSON registry
+    - `default_rating: float` – Starting rating for unknown agents (1500)
+    - `k_factor: float` – Elo K-factor applied to rating updates (32)
+    - `ratings: Dict[str, float]` – Mapping of model_id to current rating
+  * **Key Methods:**
+    - `load()` – Read registry from file if it exists
+    - `save()` – Persist current ratings to disk
+    - `get_rating(model_id)` – Retrieve rating for identifier
+    - `update_ratings(model_a_id, model_b_id, results)` – Apply match outcomes
+  * **Interconnections:**
+    * **Internal Calls:** Used by `keisei.evaluation.evaluate.Evaluator`
+    * **External Systems:** Filesystem for persistence
+  * **Lifecycle & State:** Automatically loads from disk on initialization via `__post_init__`; callers must invoke `save()` to persist updates.
+  * **Threading/Concurrency:** Not thread-safe; external synchronization required if accessed concurrently.
+  * **Usage Example:**
+    ```python
+    elo = EloRegistry(Path("elo.json"))
+    elo.update_ratings("agentA", "agentB", ["agent_win", "opponent_win"])
+    elo.save()
+    ```
+
+---
+
+### 4. Functions/Methods ⚙️
+
+#### `load()`
+* **Defined In:** `elo_registry.py`
+* **Belongs To:** `EloRegistry`
+* **Purpose:** Load ratings from disk if the registry file exists.
+* **Parameters:** None
+* **Returns:** `None`
+* **Raises/Exceptions:** Handles `json.JSONDecodeError` and `OSError` internally, defaulting to empty registry.
+* **Side Effects:** Reads the JSON file.
+
+#### `save()`
+* **Defined In:** `elo_registry.py`
+* **Belongs To:** `EloRegistry`
+* **Purpose:** Write current ratings to disk.
+* **Parameters:** None
+* **Returns:** `None`
+* **Raises/Exceptions:** Silently ignores `OSError` when writing fails.
+* **Side Effects:** Writes JSON file to configured path.
+
+#### `get_rating(model_id)`
+* **Defined In:** `elo_registry.py`
+* **Belongs To:** `EloRegistry`
+* **Purpose:** Retrieve rating for given agent id, falling back to default rating.
+* **Parameters:** `model_id: str`
+* **Returns:** `float` rating value
+
+#### `update_ratings(model_a_id, model_b_id, results)`
+* **Defined In:** `elo_registry.py`
+* **Belongs To:** `EloRegistry`
+* **Purpose:** Update ratings for two agents based on a list of result strings (`"agent_win"`, `"opponent_win"`, or other for draw).
+* **Parameters:**
+  - `model_a_id: str` – Evaluated agent identifier
+  - `model_b_id: str` – Opponent identifier
+  - `results: List[str]` – Sequence of game results
+* **Returns:** `None`
+* **Algorithmic Note:** Uses standard Elo expected-score formula and K-factor.
+
+---
+
+### 5. Shared or Complex Data Structures 📊
+
+None – registry stores a simple `Dict[str, float]` loaded from JSON.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  ```
+  evaluation/evaluate.py → EloRegistry
+  ```
+* **Cross-Folder Imports:** None other than `evaluate.py` usage.
+* **Data Flow Summary:**
+  `Evaluator` loads registry → evaluations run → results list passed to `update_ratings` → new ratings saved back to JSON file.
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:** Negligible; operations are simple dictionary manipulations and small file I/O.
+* **Security:** Registry file path should be trusted; no sanitization beyond Python's `json` handling.
+* **Error Handling & Logging:** Errors while loading/saving are silently ignored to avoid failing evaluation runs.
+* **Scalability Concerns:** Suitable for a small number of agents; large registries may need different storage.
+* **Testing & Instrumentation:**
+  * Tests located at `tests/evaluation/test_elo_registry.py` ensure rating updates work as expected.
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:** None.
+* **CLI Interfaces / Entry Points:** Not standalone; used by `evaluate.py` which passes path via config.
+* **Config File Schema:** Path to Elo registry specified in `EvaluationConfig.elo_registry_path`.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **Elo Rating:** Numerical skill rating where 400 points corresponds to a 10x expected win rate difference.
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+* **Known Issues:** None.
+* **TODOs / Deferred Features:**
+  - Potential future support for decay or season reset logic.
+* **Suggested Refactors:** None.
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Use this registry to track long-term agent performance. Always call `save()` after updating to persist results.

--- a/docs/component_audit/training_adaptive_display.md
+++ b/docs/component_audit/training_adaptive_display.md
@@ -1,0 +1,167 @@
+# Software Documentation Template for Subsystems - Adaptive Display Manager
+
+## 📘 adaptive_display.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `keisei/training/adaptive_display.py`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `Documentation Agent`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Decide which terminal user interface layout should be used based on terminal size and configuration. Helps `TrainingDisplay` select between compact and enhanced layouts.
+* **Key Responsibilities:**
+  - Inspect terminal width/height using Rich or `os.get_terminal_size`
+  - Detect Unicode rendering capability
+  - Choose layout variant (`"compact"` or `"enhanced"`)
+* **Domain Context:**
+  Terminal UI for monitoring training progress. Layout choice impacts how much information can be displayed.
+* **High-Level Architecture / Interaction Summary:**
+  `AdaptiveDisplayManager` is instantiated by `TrainingDisplay`. It queries terminal characteristics and consults `DisplayConfig` to return the preferred layout string.
+
+---
+
+### 2. Modules 📦
+
+* **Module Name:** `adaptive_display.py`
+  * **Purpose:** Utility to pick an appropriate TUI layout based on runtime environment.
+  * **Design Patterns Used:** Simple strategy/heuristic pattern.
+  * **Key Functions/Classes Provided:**
+    - `TerminalInfo` dataclass
+    - `AdaptiveDisplayManager` class
+  * **Configuration Surface:**
+    - Reads settings from `DisplayConfig` (e.g., `enable_enhanced_layout`)
+  * **Dependencies:**
+    * **Internal:** `keisei.config_schema.DisplayConfig`
+    * **External:** `os`, `rich.console.Console`
+  * **External API Contracts:** None – used internally by display manager.
+  * **Side Effects / Lifecycle Considerations:** None beyond terminal size queries.
+  * **Usage Examples:**
+    ```python
+    manager = AdaptiveDisplayManager(display_cfg)
+    layout = manager.choose_layout(Console())
+    ```
+
+---
+
+### 3. Classes 🏛️
+
+* **Class Name:** `TerminalInfo`
+  * **Defined In Module:** `adaptive_display.py`
+  * **Purpose:** Simple container describing terminal width, height and Unicode capability.
+  * **Design Role:** Lightweight data transfer object.
+  * **Inheritance:** Extends `object` via `dataclass`.
+  * **Key Attributes/Properties:**
+    - `width: int` – Terminal column count
+    - `height: int` – Terminal row count
+    - `unicode_ok: bool` – Whether Unicode characters render properly
+  * **Key Methods:** None (dataclass only)
+  * **Interconnections:** Used exclusively by `AdaptiveDisplayManager`.
+  * **Lifecycle & State:** Immutable once created.
+  * **Threading/Concurrency:** N/A
+
+* **Class Name:** `AdaptiveDisplayManager`
+  * **Defined In Module:** `adaptive_display.py`
+  * **Purpose:** Inspect console and configuration to select layout type.
+  * **Design Role:** Decision helper for the UI subsystem.
+  * **Inheritance:** `object`
+  * **Key Attributes/Properties:**
+    - `config: DisplayConfig` – Display related configuration options
+  * **Key Methods:**
+    - `_get_terminal_size(console)` – Internal helper to read terminal dimensions
+    - `get_terminal_info(console)` – Return `TerminalInfo` with Unicode check
+    - `choose_layout(console)` – Return layout string
+  * **Interconnections:** Called by `TrainingDisplay` inside the `training.display` module.
+  * **Lifecycle & State:** Stateless aside from stored config.
+  * **Threading/Concurrency:** Not thread-safe but no mutable state.
+  * **Usage Example:**
+    ```python
+    adaptive = AdaptiveDisplayManager(cfg.display)
+    if adaptive.choose_layout(console) == "enhanced":
+        layout = create_enhanced()
+    ```
+
+---
+
+### 4. Functions/Methods ⚙️
+
+#### `_get_terminal_size(console)`
+* **Defined In:** `adaptive_display.py`
+* **Belongs To:** `AdaptiveDisplayManager`
+* **Purpose:** Obtain terminal dimensions using Rich console or fallback to `os.get_terminal_size`.
+* **Parameters:** `console: Console`
+* **Returns:** `Tuple[int, int]`
+* **Raises/Exceptions:** Handles `OSError` when size cannot be determined, returning default (80,24).
+* **Side Effects:** None
+
+#### `get_terminal_info(console)`
+* **Purpose:** Return a `TerminalInfo` describing terminal size and Unicode ability.
+* **Parameters:** `console: Console`
+* **Returns:** `TerminalInfo`
+
+#### `choose_layout(console)`
+* **Purpose:** Decide between `"compact"` and `"enhanced"` layout strings.
+* **Parameters:** `console: Console`
+* **Returns:** `str`
+* **Algorithmic Note:** Uses width/height thresholds (`120x25`) and the `enable_enhanced_layout` flag.
+
+---
+
+### 5. Shared or Complex Data Structures 📊
+
+* **`TerminalInfo`** – small dataclass used as return type from `get_terminal_info`.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  ```
+  training/display.py → AdaptiveDisplayManager
+  ```
+* **Cross-Folder Imports:** Uses configuration models from `keisei.config_schema`.
+* **Data Flow Summary:**
+  `TrainingDisplay` asks manager for layout → manager queries console → returns layout string → display creates layout accordingly.
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:** Negligible; simple attribute checks.
+* **Security:** None; does not process user input.
+* **Error Handling & Logging:** Gracefully handles terminal size query failures.
+* **Scalability Concerns:** None.
+* **Testing & Instrumentation:**
+  * Tested in `tests/test_display_infrastructure.py` (`test_adaptive_layout_choice`).
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:** None.
+* **CLI Interfaces / Entry Points:** None; used programmatically.
+* **Config File Schema:** Parameters provided by `DisplayConfig`.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+Not applicable.
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+* **Known Issues:** None.
+* **TODOs / Deferred Features:** Consider dynamic adjustment when terminal is resized during runtime.
+* **Suggested Refactors:** None.
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Use `AdaptiveDisplayManager` to automatically select layouts that fit the user's terminal; keep configuration in sync with available space.

--- a/docs/component_audit/training_display_components.md
+++ b/docs/component_audit/training_display_components.md
@@ -1,0 +1,160 @@
+# Software Documentation Template for Subsystems - Display Components
+
+## 📘 display_components.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `keisei/training/display_components.py`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `Documentation Agent`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Provide reusable Rich display components for the training UI, including an ASCII board renderer and sparkline visualizer.
+* **Key Responsibilities:**
+  - Define a protocol for components used by `TrainingDisplay`
+  - Render the current Shogi board state with optional move list
+  - Generate small sparklines for metric trends
+* **Domain Context:**
+  Terminal-based monitoring of RL training; visuals aid understanding of agent behaviour and performance.
+* **High-Level Architecture / Interaction Summary:**
+  `TrainingDisplay` composes these components into panels within the Rich layout. They rely on `rich` primitives and internal policy mappers for move formatting.
+
+---
+
+### 2. Modules 📦
+
+* **Module Name:** `display_components.py`
+  * **Purpose:** House auxiliary UI widgets for terminal display.
+  * **Design Patterns Used:** Protocol-based interface for renderables.
+  * **Key Functions/Classes Provided:**
+    - `DisplayComponent` protocol
+    - `ShogiBoard` class
+    - `Sparkline` class
+  * **Configuration Surface:**
+    - `ShogiBoard` constructor options (`use_unicode`, `show_moves`, `max_moves`)
+    - `Sparkline` width
+  * **Dependencies:**
+    * **Internal:** `keisei.utils.unified_logger.log_error_to_stderr`
+    * **External:** `rich` library components
+  * **External API Contracts:** None; objects return Rich `RenderableType`.
+  * **Side Effects / Lifecycle Considerations:** None aside from rendering; `ShogiBoard` logs unexpected errors during move formatting.
+  * **Usage Examples:**
+    ```python
+    board = ShogiBoard(show_moves=True)
+    panel = board.render(game_state, move_history, policy_mapper)
+    spark = Sparkline(width=10)
+    panel2 = spark.render(values=[0.1, 0.2, 0.3])
+    ```
+
+---
+
+### 3. Classes 🏛️
+
+* **Class Name:** `ShogiBoard`
+  * **Defined In Module:** `display_components.py`
+  * **Purpose:** Render an ASCII representation of the Shogi board with optional recent move list.
+  * **Design Role:** View component in the UI architecture.
+  * **Inheritance:** `object`
+  * **Key Attributes/Properties:**
+    - `use_unicode: bool` – Whether to use Japanese piece symbols
+    - `show_moves: bool` – Whether to append recent move history panel
+    - `max_moves: int` – How many recent moves to display
+  * **Key Methods:**
+    - `_piece_to_symbol(piece)` – Map board piece object to text symbol
+    - `_generate_ascii_board(board_state)` – Create multi-line ASCII board
+    - `_move_to_usi(move_tuple, policy_mapper)` – Convert move tuple to USI string
+    - `render(board_state, move_history, policy_mapper)` – Return Rich panel/group
+  * **Interconnections:**
+    * **Internal Calls:** Uses `log_error_to_stderr` on unexpected formatting errors.
+  * **Lifecycle & State:** Stateless aside from constructor flags.
+  * **Threading/Concurrency:** Not thread-safe but used in single-threaded display loop.
+  * **Usage Example:**
+    ```python
+    board = ShogiBoard(use_unicode=True, show_moves=True)
+    panel = board.render(game, history, mapper)
+    ```
+
+* **Class Name:** `Sparkline`
+  * **Defined In Module:** `display_components.py`
+  * **Purpose:** Generate compact sparkline strings to visualise metric trends.
+  * **Design Role:** Small visual component.
+  * **Inheritance:** `object`
+  * **Key Attributes/Properties:**
+    - `width: int` – Number of characters in the sparkline
+    - `chars: str` – Unicode block characters used for visualisation
+  * **Key Methods:**
+    - `generate(values)` – Produce sparkline string from numeric sequence
+    - `render(values, title)` – Return Rich panel with sparkline
+  * **Interconnections:** None beyond `rich` rendering.
+  * **Lifecycle & State:** Stateless except for configured width.
+  * **Threading/Concurrency:** N/A
+  * **Usage Example:**
+    ```python
+    spark = Sparkline(width=5)
+    panel = spark.render([1,2,3,4,5], "Policy Loss")
+    ```
+
+---
+
+### 4. Functions/Methods ⚙️
+
+Focus is on methods outlined above; there are no standalone functions.
+
+---
+
+### 5. Shared or Complex Data Structures 📊
+
+None.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):**
+  ```
+  training/display.py → ShogiBoard, Sparkline
+  ```
+* **Data Flow Summary:** Game state and metric history are passed from `TrainingDisplay`/`Trainer` into these components, which produce Rich renderables for display.
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:** Lightweight rendering; minimal overhead.
+* **Security:** No external input other than sanitized board/move data.
+* **Error Handling & Logging:** Uses `log_error_to_stderr` on unexpected failures in move formatting.
+* **Scalability Concerns:** None.
+* **Testing & Instrumentation:**
+  * See tests in `tests/test_display_infrastructure.py` (`test_shogi_board_basic_render`, `test_sparkline_generation`).
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:** None.
+* **CLI Interfaces / Entry Points:** None.
+* **Config File Schema:** Controlled indirectly via `DisplayConfig` passed from application config.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **USI:** Universal Shogi Interface notation used for representing moves.
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+* **Known Issues:** Unicode rendering depends on terminal font support.
+* **TODOs / Deferred Features:** Potential colorised board or piece highlighting.
+* **Suggested Refactors:** None.
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+These components are intended for console output only and rely on Rich for rendering. Keep their usage lightweight within the training loop to avoid slowing down performance.

--- a/docs/component_audit/training_elo_rating.md
+++ b/docs/component_audit/training_elo_rating.md
@@ -1,0 +1,141 @@
+# Software Documentation Template for Subsystems - Training Elo Rating System
+
+## 📘 elo_rating.py as of 2025-06-01
+
+**Project Name:** `Keisei - Deep Reinforcement Learning Shogi Client`
+**Folder Path:** `keisei/training/elo_rating.py`
+**Documentation Version:** `1.0`
+**Date:** `2025-06-01`
+**Responsible Author or Agent ID:** `Documentation Agent`
+
+---
+
+### 1. Overview 📜
+
+* **Purpose of this Module:**
+  Track Elo rating changes between the agent playing black and white during self-play training sessions.
+* **Key Responsibilities:**
+  - Maintain separate ratings for black and white sides
+  - Update ratings after each game using the Elo formula
+  - Provide a simple assessment of rating imbalance
+* **Domain Context:**
+  Used in training to monitor potential bias between player colors and overall progress.
+* **High-Level Architecture / Interaction Summary:**
+  Independent helper class that can be instantiated by training code or metrics manager to accumulate ratings over time.
+
+---
+
+### 2. Modules 📦
+
+* **Module Name:** `elo_rating.py`
+  * **Purpose:** Utility implementing a two-player Elo system.
+  * **Design Patterns Used:** Minimal stateful object with statistical update.
+  * **Key Functions/Classes Provided:** `EloRatingSystem`
+  * **Configuration Surface:** Initial rating and K-factor parameters.
+  * **Dependencies:**
+    * **Internal:** `keisei.shogi.shogi_core_definitions.Color`
+    * **External:** Python standard library only
+  * **External API Contracts:** None.
+  * **Side Effects / Lifecycle Considerations:** Maintains history of rating updates.
+  * **Usage Examples:**
+    ```python
+    elo = EloRatingSystem()
+    elo.update_ratings(Color.BLACK)
+    print(elo.get_strength_assessment())
+    ```
+
+---
+
+### 3. Classes 🏛️
+
+* **Class Name:** `EloRatingSystem`
+  * **Defined In Module:** `elo_rating.py`
+  * **Purpose:** Calculate and store Elo ratings for each player colour.
+  * **Design Role:** Lightweight statistics tracker.
+  * **Inheritance:** `object`
+  * **Key Attributes/Properties:**
+    - `initial_rating: float` – Starting rating for both sides
+    - `k_factor: float` – K-factor for rating adjustments
+    - `black_rating: float` – Current rating for black
+    - `white_rating: float` – Current rating for white
+    - `rating_history: List[Dict[str, float]]` – Log of ratings after each update
+  * **Key Methods:**
+    - `_expected_score(rating_a, rating_b)` – Helper for Elo expectation formula
+    - `update_ratings(winner_color)` – Apply update based on winner
+    - `get_strength_assessment()` – Return textual comparison between sides
+  * **Interconnections:** Consumed by `MetricsManager` tests in `tests/test_display_infrastructure.py`.
+  * **Lifecycle & State:** Mutable ratings updated per game.
+  * **Threading/Concurrency:** Not thread-safe.
+  * **Usage Example:**
+    ```python
+    elo = EloRatingSystem(initial_rating=1500)
+    result = elo.update_ratings(Color.WHITE)
+    ```
+
+---
+
+### 4. Functions/Methods ⚙️
+
+#### `update_ratings(winner_color)`
+* **Defined In:** `elo_rating.py`
+* **Belongs To:** `EloRatingSystem`
+* **Purpose:** Update internal ratings based on winning colour or draw (`None`).
+* **Parameters:** `winner_color: Optional[Color]`
+* **Returns:** `Dict[str, float]` summary of new ratings
+* **Algorithmic Note:** Standard Elo calculation with symmetrical K-factor.
+
+#### `get_strength_assessment()`
+* **Purpose:** Provide a qualitative description of rating difference.
+* **Returns:** `str`
+
+---
+
+### 5. Shared or Complex Data Structures 📊
+
+* **`rating_history`** – list of dictionaries with keys `black_rating`, `white_rating`, `difference`.
+
+---
+
+### 6. Inter-Module Relationships & Data Flow 🔄
+
+* **Dependency Graph (Internal):** None
+* **Data Flow Summary:** Training loop records winner after each game → `update_ratings` is called → ratings stored and optionally displayed.
+
+---
+
+### 7. Non-Functional Aspects 🛠️
+
+* **Performance:** Minimal computations per game.
+* **Security:** Not applicable.
+* **Error Handling & Logging:** None; assumes valid Color input.
+* **Scalability Concerns:** None.
+* **Testing & Instrumentation:**
+  * Covered by `tests/test_display_infrastructure.py::test_elo_rating_updates`.
+
+---
+
+### 8. Configuration & Environment ♻️
+
+* **Environment Variables:** None.
+* **CLI Interfaces / Entry Points:** None.
+* **Config File Schema:** Parameter defaults may be overridden when instantiating the class.
+
+---
+
+### 9. Glossary (Optional) 📖
+
+* **K-factor:** Parameter determining Elo rating sensitivity to new results.
+
+---
+
+### 10. Known Issues, TODOs, Future Work 🧭
+
+* **Known Issues:** None.
+* **TODOs / Deferred Features:** Option to decay ratings over time.
+* **Suggested Refactors:** None.
+
+---
+
+## Notes for AI/Agent Developers 🧠
+
+Use this utility to monitor colour advantage during self-play. Ratings are not persisted automatically.


### PR DESCRIPTION
## Summary
- add new component_audit docs for missing modules
  - `evaluation_elo_registry.md`
  - `training_adaptive_display.md`
  - `training_display_components.md`
  - `training_elo_rating.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6841926137108323ac81a21b4ee4e443