### PR TITLE
Add board alignment test

### DIFF
--- a/keisei/training/display_components.py
+++ b/keisei/training/display_components.py
@@ -53,7 +53,12 @@ class ShogiBoard:
         return piece.symbol()
 
     def _generate_ascii_board(self, board_state) -> str:
-        lines: List[str] = ["  9 8 7 6 5 4 3 2 1"]
+        if self.use_unicode:
+            header = "  " + "".join(f"{i}  " for i in range(9, 0, -1))
+        else:
+            header = "  " + "".join(f"{i} " for i in range(9, 0, -1))
+
+        lines: List[str] = [header]
         for r_idx, row in enumerate(board_state.board):
             line_parts: List[str] = [f"{9 - r_idx} "]
             for piece in reversed(row):

--- a/tests/test_shogi_board_alignment.py
+++ b/tests/test_shogi_board_alignment.py
@@ -1,0 +1,15 @@
+import pytest
+from keisei.training.display_components import ShogiBoard
+from wcwidth import wcswidth
+
+class DummyBoard:
+    def __init__(self):
+        self.board = [[None for _ in range(9)] for _ in range(9)]
+
+@pytest.mark.parametrize("use_unicode", [True, False])
+def test_shogi_board_line_width_alignment(use_unicode):
+    board = DummyBoard()
+    shogi_board = ShogiBoard(use_unicode=use_unicode)
+    ascii_board = shogi_board._generate_ascii_board(board)
+    line_widths = [wcswidth(line) for line in ascii_board.splitlines()]
+    assert len(set(line_widths)) == 1


### PR DESCRIPTION
## Summary
- ensure ShogiBoard output lines have equal display width
- adjust header spacing in `ShogiBoard` so all lines line up

## Testing
- `pytest tests/test_shogi_board_alignment.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841928cf4a08323baf0b510256ef0df