### PR TITLE
Fix ShogiBoard unicode cell width bug

### DIFF
--- a/keisei/training/display_components.py
+++ b/keisei/training/display_components.py
@@ -74,6 +74,7 @@ class ShogiBoard:
                 "竜",
                 "・",
             ]
+            cell_width = max(wcswidth(sym) for sym in reference_symbols)
         else:
             reference_symbols = [
                 "P",
@@ -149,6 +150,8 @@ class Sparkline:
         self.chars = "▁▂▃▄▅▆▇█"
 
     def generate(self, values: Sequence[float]) -> str:
+        if not values:
+            return "".join([" " for _ in range(self.width)])
         if len(values) < 2:
             return "".join(["─" for _ in range(self.width)])
 


### PR DESCRIPTION
## Summary
- ensure `cell_width` is initialized when rendering Unicode boards
- handle empty metrics in `Sparkline.generate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c687038c832380dcf627eb779354