### PR TITLE
UI display refactor

### DIFF
--- a/keisei/training/display_components.py
+++ b/keisei/training/display_components.py
@@ -7,11 +7,11 @@ from collections import deque
 from wcwidth import wcswidth
 
 from keisei.utils.unified_logger import log_error_to_stderr
+from keisei.shogi.shogi_core_definitions import Color
 
 from rich.console import RenderableType, Group
 from rich.panel import Panel
 from rich.text import Text
-from rich.layout import Layout
 from rich.layout import Layout
 
 
@@ -31,17 +31,49 @@ class ShogiBoard:
         use_unicode: bool = True,
         show_moves: bool = False,
         max_moves: int = 10,
-        indent_spaces: int = 0,
-        vertical_offset: int = 0,
-        bottom_padding: int = 0,
     ) -> None:
         self.use_unicode = use_unicode
         self.show_moves = show_moves
         self.max_moves = max_moves
-        self.indent_spaces = indent_spaces
-        self.vertical_offset = vertical_offset
-        self.bottom_padding = bottom_padding
-        self.bottom_padding = bottom_padding
+
+        if self.use_unicode:
+            reference_symbols = [
+                "歩",
+                "香",
+                "桂",
+                "銀",
+                "金",
+                "角",
+                "飛",
+                "王",
+                "と",
+                "成香",
+                "成桂",
+                "成銀",
+                "馬",
+                "竜",
+                "・",
+            ]
+        else:
+            reference_symbols = [
+                "P",
+                "L",
+                "N",
+                "S",
+                "G",
+                "B",
+                "R",
+                "K",
+                "+P",
+                "+L",
+                "+N",
+                "+S",
+                "+B",
+                "+R",
+                ".",
+            ]
+        widths = [wcswidth(sym) or len(sym) for sym in reference_symbols]
+        self.cell_width = max(widths)
 
     def _piece_to_symbol(self, piece) -> str:
         if not piece:
@@ -69,63 +101,13 @@ class ShogiBoard:
         return piece.symbol()
 
     def _colorize(self, symbol: str, piece) -> str:
-        from keisei.shogi.shogi_core_definitions import Color
-
-        if piece.color == Color.BLACK:
-            return f"[bright_red]{symbol}[/bright_red]"
-        return f"[bright_blue]{symbol}[/bright_blue]"
-
-    def _colorize(self, symbol: str, piece) -> str:
-        from keisei.shogi.shogi_core_definitions import Color
-
         if piece.color == Color.BLACK:
             return f"[bright_red]{symbol}[/bright_red]"
         return f"[bright_blue]{symbol}[/bright_blue]"
 
     def _generate_ascii_board(self, board_state) -> str:
-        if self.use_unicode:
-            reference_symbols = [
-                "歩",
-                "香",
-                "桂",
-                "銀",
-                "金",
-                "角",
-                "飛",
-                "王",
-                "と",
-                "成香",
-                "成桂",
-                "成銀",
-                "馬",
-                "竜",
-                "・",
-            ]
-            cell_width = max(wcswidth(sym) for sym in reference_symbols)
-        else:
-            reference_symbols = [
-                "P",
-                "L",
-                "N",
-                "S",
-                "G",
-                "B",
-                "R",
-                "K",
-                "+P",
-                "+L",
-                "+N",
-                "+S",
-                "+B",
-                "+R",
-                ".",
-            ]
-        
-        # Handle case where wcswidth returns None
-        widths = [wcswidth(sym) or len(sym) for sym in reference_symbols]
-        cell_width = max(widths)
-
-        indent = " " * self.indent_spaces
+        cell_width = self.cell_width
+        indent = ""
         start_padding = cell_width - 1 if self.use_unicode else cell_width
         header = (
             indent
@@ -148,8 +130,6 @@ class ShogiBoard:
                 padded = pad(colored)
                 line_parts.append(padded + " ")
         lines.append("".join(line_parts).rstrip())
-        lines = ["" for _ in range(self.vertical_offset)] + lines
-        lines += ["" for _ in range(self.bottom_padding)]
         return "\n".join(lines)
 
     def _move_to_usi(self, move_tuple, policy_mapper) -> str:
@@ -161,15 +141,9 @@ class ShogiBoard:
             log_error_to_stderr("ShogiBoard", f"Unexpected error in _move_to_usi: {e}")
             raise
 
-    def render(
-        self,
-        board_state=None,
-        move_history=None,
-        policy_mapper=None,
-        move_strings=None,
-    ) -> RenderableType:  # type: ignore[override]
+    def render(self, board_state=None, **_kwargs) -> RenderableType:  # type: ignore[override]
         if not board_state:
-            return Panel(Text("No active game"), title="Shogi Board")
+            return Panel(Text("No active game"), title="Main Board")
 
         ascii_board = self._generate_ascii_board(board_state)
         board_panel = Panel(
@@ -177,41 +151,22 @@ class ShogiBoard:
             title="Main Board",
             border_style="blue",
         )
+        return board_panel
 
-        if not self.show_moves:
-            return board_panel
 
-        if move_strings:
-            indent = " "
-            last_msgs = move_strings[-self.max_moves :]
-            formatted = [f"{indent}{msg}" for msg in last_msgs]
-            moves_panel = Panel(
-                Text("\n".join(formatted)), border_style="yellow", title="Recent Moves"
-            )
-            container = Layout()
-            container.split_column(
-                Layout(board_panel, size=len(ascii_board.splitlines()) + 2),
-                Layout(moves_panel, ratio=1),
-            )
-            return container
+class RecentMovesPanel:
+    """Renders the list of recent moves."""
 
-        if not move_history or policy_mapper is None:
-            return board_panel
+    def __init__(self, max_moves: int = 20):
+        self.max_moves = max_moves
 
+    def render(self, move_strings: Optional[List[str]] = None) -> RenderableType:
+        if not move_strings:
+            return Panel(Text("No moves yet."), title="Recent Moves", border_style="yellow")
         indent = " "
-        last_moves = move_history[-self.max_moves :]
-        lines = [self._move_to_usi(mv, policy_mapper) for mv in last_moves]
-        start_idx = len(move_history) - len(last_moves) + 1
-        formatted = [f"{indent}{start_idx + i:3d}. {mv}" for i, mv in enumerate(lines)]
-        moves_panel = Panel(
-            Text("\n".join(formatted)), border_style="yellow", title="Recent Moves"
-        )
-        container = Layout()
-        container.split_column(
-            Layout(board_panel, size=len(ascii_board.splitlines()) + 2),
-            Layout(moves_panel, ratio=1),
-        )
-        return container
+        last_msgs = move_strings[-self.max_moves :]
+        formatted = [f"{indent}{msg}" for msg in last_msgs]
+        return Panel(Text("\n".join(formatted)), title="Recent Moves", border_style="yellow")
 
 
 class Sparkline:
@@ -241,14 +196,6 @@ class Sparkline:
             spark = "▁" * (self.width - len(spark)) + spark
         return spark
 
-    def render(self, values: Optional[Sequence[float]] = None, title: str = "Trends") -> RenderableType:  # type: ignore[override]
-        values = values or []
-        spark = (
-            self.generate(list(values))
-            if values
-            else "".join(["─" for _ in range(self.width)])
-        )
-        return Panel(Text(f"{title}: {spark}", style="cyan"), border_style="cyan")
 
 
 class RollingAverageCalculator:

--- a/keisei/training/display_manager.py
+++ b/keisei/training/display_manager.py
@@ -87,7 +87,7 @@ class DisplayManager:
         if self.display:
             self.display.update_progress(trainer, speed, pending_updates)
 
-    def update_log_panel(self, trainer) -> None:
+    def refresh_dashboard_panels(self, trainer) -> None:
         """
         Update the log panel display.
 
@@ -95,7 +95,7 @@ class DisplayManager:
             trainer: The trainer instance
         """
         if self.display:
-            self.display.update_log_panel(trainer)
+            self.display.refresh_dashboard_panels(trainer)
 
     def start_live_display(self) -> Optional[Live]:
         """

--- a/keisei/training/training_loop_manager.py
+++ b/keisei/training/training_loop_manager.py
@@ -462,10 +462,10 @@ class TrainingLoopManager:
     def _handle_display_updates(self):
         """Handles periodic display updates based on time and step intervals."""
         if self.trainer.global_timestep % self.config.training.render_every_steps == 0:
-            if hasattr(self.display, "update_log_panel") and callable(
-                self.display.update_log_panel
+            if hasattr(self.display, "refresh_dashboard_panels") and callable(
+                self.display.refresh_dashboard_panels
             ):
-                self.display.update_log_panel(self.trainer)
+                self.display.refresh_dashboard_panels(self.trainer)
 
         self._update_display_if_needed()
 

--- a/tests/test_display_infrastructure.py
+++ b/tests/test_display_infrastructure.py
@@ -1,7 +1,10 @@
 from keisei.config_schema import DisplayConfig
 from keisei.training.adaptive_display import AdaptiveDisplayManager
-from keisei.training.display_components import Sparkline, ShogiBoard
-from rich.console import Group
+from keisei.training.display_components import (
+    Sparkline,
+    ShogiBoard,
+    RecentMovesPanel,
+)
 from keisei.training.elo_rating import EloRatingSystem
 from keisei.training.metrics_manager import MetricsHistory
 from keisei.shogi.shogi_core_definitions import Color
@@ -67,13 +70,8 @@ def test_shogi_board_basic_render():
     assert getattr(panel, "title", "") == "Main Board"
 
 
-def test_shogi_board_render_with_moves():
-    board = ShogiBoard(show_moves=True, max_moves=2)
-    move_history = [(1, 2, 3, 4, 5), (2, 3, 4, 5, 6), (3, 4, 5, 6, 7)]
-
-    class DummyMapper:
-        def shogi_move_to_usi(self, mv):
-            return "".join(str(x) for x in mv)
-
-    layout = board.render(DummyBoard(), move_history, DummyMapper())
-    assert hasattr(layout, "__rich__") or hasattr(layout, "render") or True
+def test_recent_moves_panel_render():
+    panel = RecentMovesPanel(max_moves=2)
+    moves = ["7g7f", "8c8d", "2g2f"]
+    rendered = panel.render(moves)
+    assert "8c8d" in rendered.renderable.plain


### PR DESCRIPTION
## Summary
- refactor `ShogiBoard` rendering and add `RecentMovesPanel`
- restructure `TrainingDisplay` layout and panel refresh logic
- create separate stats panel and update board/move rendering
- update training loop and display manager to call new refresh method
- adjust tests for refactored display components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684244a159f083239fd114c8805fc06d