### PR TITLE
Refactor dashboard panels with rich.Table

### DIFF
--- a/keisei/training/training_loop_manager.py
+++ b/keisei/training/training_loop_manager.py
@@ -379,7 +379,11 @@ class TrainingLoopManager:
         ep_metrics_str = f"L:{ep_len} R:{ep_rew:.2f}"
         turns_count = ep_len
         self.trainer.metrics_manager.log_episode_metrics(
-            ep_len, turns_count, result, ep_rew
+            ep_len,
+            turns_count,
+            result,
+            ep_rew,
+            self.trainer.step_manager.move_history if self.trainer.step_manager else None,
         )
 
         total_games = (


### PR DESCRIPTION
## Summary
- insert new PieceStandPanel and expanded GameStatisticsPanel
- track clip fraction metric and favourite openings
- fix layout to show captured pieces panel between board and move list
- compute clip fraction in PPOAgent and expose via metrics manager
- add batch size config fix and render metrics table with extra row
- tone-colored dots for empty squares on the board
- recent moves panel now expands and game stats show readable openings

## Testing
- `pytest tests/test_display_components.py::test_sparkline_bounded_generation -q`
- `pytest tests/test_display_components.py::test_multi_metric_sparkline_render -q`


------
https://chatgpt.com/codex/tasks/task_e_6843a9827ffc83238746ab3d4680ad9f