### PR TITLE
Add hot square stats and UI updates

### DIFF
--- a/keisei/training/display.py
+++ b/keisei/training/display.py
@@ -162,12 +162,12 @@ class TrainingDisplay:
             TextColumn("• {task.fields[ep_metrics]}", style="bright_cyan"),
             TextColumn("• {task.fields[ppo_metrics]}", style="bright_yellow"),
             TextColumn(
-                "• Wins B:{task.fields[black_wins_cum]} W:{task.fields[white_wins_cum]} D:{task.fields[draws_cum]}",
+                "• Wins S:{task.fields[black_wins_cum]} G:{task.fields[white_wins_cum]} D:{task.fields[draws_cum]}",
                 style="bright_green",
             ),
             TextColumn(
-                "• Rates B:{task.fields[black_win_rate]:.1%} "
-                "W:{task.fields[white_win_rate]:.1%} "
+                "• Rates S:{task.fields[black_win_rate]:.1%} "
+                "G:{task.fields[white_win_rate]:.1%} "
                 "D:{task.fields[draw_rate]:.1%}",
                 style="bright_blue",
             ),
@@ -238,7 +238,7 @@ class TrainingDisplay:
             ("Entropy", "entropies"),
             ("KL Divergence", "kl_divergences"),
             ("PPO Clip Frac", "clip_fractions"),
-            ("Win Rate B", "win_rates_black"),
+            ("Win Rate S", "win_rates_black"),
             ("Draw Rate", "draw_rates"),
         ]
 
@@ -299,8 +299,9 @@ class TrainingDisplay:
         if self.using_enhanced_layout:
             if self.board_component:
                 try:
+                    hot = trainer.metrics_manager.get_hot_squares(top_n=3)
                     self.layout["board_panel"].update(
-                        self.board_component.render(trainer.game)
+                        self.board_component.render(trainer.game, hot_squares=hot)
                     )
                 except Exception as e:
                     self.rich_console.log(

--- a/keisei/training/display_components.py
+++ b/keisei/training/display_components.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Protocol, Optional, List, Sequence, Dict
 from collections import deque, Counter
-import ast
 from wcwidth import wcswidth
 
 from keisei.utils.unified_logger import log_error_to_stderr
@@ -116,7 +115,13 @@ class ShogiBoard:
         padding = self.cell_width - width
         return symbol + (" " * padding)
 
-    def _generate_rich_table(self, board_state) -> Table:
+    def _get_shogi_notation(self, row: int, col: int) -> str:
+        """Convert board indices to shogi square notation like '7f'."""
+        file_num = 9 - col
+        rank_letter = chr(ord("a") + row)
+        return f"{file_num}{rank_letter}"
+
+    def _generate_rich_table(self, board_state, hot_squares: Optional[List[str]] = None) -> Table:
         """Create a 10×10 Table for the board."""
         light_bg_color = "#EEC28A"
         dark_bg_color = "#C19A55"
@@ -142,6 +147,7 @@ class ShogiBoard:
         file_labels = [""] + [str(n) for n in range(9, 0, -1)]
         table.add_row(*[Text(lbl, style="bold") for lbl in file_labels])
 
+        hot_squares = hot_squares or []
         for r_idx, row in enumerate(board_state.board):
             rank_label = str(9 - r_idx)
             row_cells: List[Text] = [Text(rank_label, style="bold")]
@@ -161,17 +167,21 @@ class ShogiBoard:
                     cell_renderable = Text(padded, style=dot_color)
 
                 cell_renderable.stylize(bg_style)
+                board_col = len(row) - 1 - c_idx
+                notation = self._get_shogi_notation(r_idx, board_col)
+                if notation in hot_squares:
+                    cell_renderable.stylize(Style(frame=True, color="red"))
                 row_cells.append(cell_renderable)
 
             table.add_row(*row_cells)
         return table
 
-    def render(self, board_state=None, **_kwargs) -> RenderableType:
+    def render(self, board_state=None, hot_squares: Optional[List[str]] = None, **_kwargs) -> RenderableType:
         """Returns a Panel containing a Rich Table of the current board."""
         if not board_state:
             return Panel(Text("No active game"), title="Main Board", border_style="blue")
 
-        board_table = self._generate_rich_table(board_state)
+        board_table = self._generate_rich_table(board_state, hot_squares)
         return Panel(Align.center(board_table), title="Main Board", border_style="blue")
 
 
@@ -331,6 +341,19 @@ class GameStatisticsPanel:
                     total_value += piece_values.get(key, 0)
         return total_value
 
+    def _format_hand(self, hand: Dict[str, int]) -> str:
+        symbols = {
+            "PAWN": "歩",
+            "LANCE": "香",
+            "KNIGHT": "桂",
+            "SILVER": "銀",
+            "GOLD": "金",
+            "BISHOP": "角",
+            "ROOK": "飛",
+        }
+        parts = [f"{symbols.get(getattr(k, 'name', k), '?')}x{v}" for k, v in hand.items() if v > 0]
+        return " ".join(parts) or ""
+
     def render(
         self,
         game,
@@ -338,69 +361,35 @@ class GameStatisticsPanel:
         metrics_manager=None,
         policy_mapper=None,
     ) -> RenderableType:
-        if (
-            not game
-            or move_history is None
-            or metrics_manager is None
-            or policy_mapper is None
-        ):
-            return Panel(
-                "Waiting for game to start...",
-                title="Game Statistics",
-                border_style="green",
-            )
+        if not game or not move_history or not metrics_manager:
+            return Panel("Waiting for game to start...", title="Game Statistics", border_style="green")
 
-        sente_material = self._calculate_material(game, Color.BLACK)
-        gote_material = self._calculate_material(game, Color.WHITE)
+        sente_material = self._calculate_material(game.board, Color.BLACK)
+        gote_material = self._calculate_material(game.board, Color.WHITE)
         material_adv = sente_material - gote_material
-
-        square_usage = Counter()
-        for move in move_history:
-            try:
-                parts = move.split(" from ")[1].split(" to ")
-                square_usage.update([parts[0], parts[1].strip(".")])
-            except IndexError:
-                continue
-        hot_squares = ", ".join([sq[0] for sq in square_usage.most_common(3)]) or "N/A"
+        is_in_check = getattr(game, 'is_in_check', lambda: False)()
+        hot_squares = metrics_manager.get_hot_squares(top_n=3)
 
         sente_openings = metrics_manager.sente_opening_history
         gote_openings = metrics_manager.gote_opening_history
-        fav_sente_tuple = (
-            Counter(sente_openings).most_common(1)[0][0] if sente_openings else None
-        )
-        fav_gote_tuple = (
-            Counter(gote_openings).most_common(1)[0][0] if gote_openings else None
-        )
-
-        try:
-            fav_sente_opening = (
-                policy_mapper.shogi_move_to_usi(ast.literal_eval(fav_sente_tuple))
-                if fav_sente_tuple
-                else "N/A"
-            )
-        except Exception:
-            fav_sente_opening = "N/A"
-
-        try:
-            fav_gote_opening = (
-                policy_mapper.shogi_move_to_usi(ast.literal_eval(fav_gote_tuple))
-                if fav_gote_tuple
-                else "N/A"
-            )
-        except Exception:
-            fav_gote_opening = "N/A"
+        fav_sente_opening = Counter(sente_openings).most_common(1)[0][0] if sente_openings else "N/A"
+        fav_gote_opening = Counter(gote_openings).most_common(1)[0][0] if gote_openings else "N/A"
 
         table = Table.grid(expand=True, padding=(0, 2))
         table.add_column(style="bold cyan", no_wrap=True)
-        table.add_column(justify="right")
+        table.add_column()
 
-        check_status = (
-            "[red]CHECK[/]" if game.is_in_check(game.current_player) else "Clear"
-        )
-        table.add_row("Check Status:", check_status)
+        table.add_row("Check Status:", "[red]CHECK[/]" if is_in_check else "Clear")
         table.add_row("Material Adv:", f"{material_adv:+.1f} (Sente)")
-        table.add_row("Hot Squares:", hot_squares)
+        table.add_row("Hot Squares:", ", ".join(hot_squares) or "N/A")
         table.add_row("Fav. Sente Opening:", fav_sente_opening)
         table.add_row("Fav. Gote Opening:", fav_gote_opening)
 
-        return Panel(table, title="Game Statistics", border_style="green")
+        sente_hand_str = self._format_hand(getattr(game, 'hands', {}).get(Color.BLACK, {}))
+        gote_hand_str = self._format_hand(getattr(game, 'hands', {}).get(Color.WHITE, {}))
+        hand_info = Group(
+             Text.from_markup("\n[bold]Sente's Hand:[/bold]"), Text(sente_hand_str or "None"),
+             Text.from_markup("\n[bold]Gote's Hand:[/bold]"), Text(gote_hand_str or "None")
+        )
+
+        return Panel(Group(table, hand_info), title="Game Statistics", border_style="green")

--- a/keisei/training/step_manager.py
+++ b/keisei/training/step_manager.py
@@ -509,11 +509,12 @@ class StepManager:
             piece_info_for_demo,
         )
 
-        player_display = (
-            current_player_name.title()
-            if current_player_name.upper() in {"BLACK", "WHITE"}
-            else current_player_name
-        )
+        if current_player_name.upper() == "BLACK":
+            player_display = "Sente"
+        elif current_player_name.upper() == "WHITE":
+            player_display = "Gote"
+        else:
+            player_display = current_player_name
         log_msg = f"Move {episode_length + 1} ({player_display}): {move_str}"
         self.move_log.append(log_msg)
         self.move_history.append(selected_move)
@@ -549,9 +550,9 @@ class StepManager:
     def _format_game_outcome_message(self, winner: Optional[str], reason: str) -> str:
         """Helper to format the game outcome message."""
         if winner == "black":
-            return f"Black wins by {reason}."
+            return f"Sente wins by {reason}."
         if winner == "white":
-            return f"White wins by {reason}."
+            return f"Gote wins by {reason}."
         if winner is None:
             return f"Draw by {reason}."
         return f"Game ended: {winner} by {reason}."  # Should ideally not be reached with current logic

--- a/keisei/training/training_loop_manager.py
+++ b/keisei/training/training_loop_manager.py
@@ -384,6 +384,7 @@ class TrainingLoopManager:
             result,
             ep_rew,
             self.trainer.step_manager.move_history if self.trainer.step_manager else None,
+            self.trainer.policy_output_mapper,
         )
 
         total_games = (

--- a/tests/test_step_manager.py
+++ b/tests/test_step_manager.py
@@ -476,7 +476,7 @@ class TestHandleEpisodeEnd:
         mock_logger.assert_called()
         log_message = mock_logger.call_args[0][0]
         assert "Episode 18 finished" in log_message
-        assert "Black wins by checkmate" in log_message
+        assert "Sente wins by checkmate" in log_message
 
         # Verify wandb data was logged
         wandb_data = mock_logger.call_args[1]["wandb_data"]
@@ -513,7 +513,7 @@ class TestHandleEpisodeEnd:
 
         # Verify white win message
         log_message = mock_logger.call_args[0][0]
-        assert "White wins by timeout" in log_message
+        assert "Gote wins by timeout" in log_message
 
     def test_episode_end_draw(
         self, step_manager, sample_episode_state, mock_logger, mock_components


### PR DESCRIPTION
## Summary
- track square usage and favourite openings in metrics manager
- highlight hot squares and show stats in dashboard
- update terminology to Sente/Gote across UI and logs
- adjust game statistics panel and board rendering
- update tests for new messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68442f7629948323a0c5f69a37ede171