### PR TITLE
Implement Hot Square tracking and display improvements

### DIFF
--- a/keisei/config_schema.py
+++ b/keisei/config_schema.py
@@ -294,12 +294,24 @@ class DisplayConfig(BaseModel):
         description="Display recent moves under the board when demo mode is active",
     )
     move_list_length: int = Field(10, description="Number of recent moves to display")
+    moves_latest_top: bool = Field(
+        True,
+        description="Display newest move at top of recent moves panel",
+    )
+    moves_flash_ms: int = Field(
+        500,
+        description="Highlight newest move for N milliseconds (0 disables)",
+    )
     show_moves_trend: bool = Field(True, description="Display moves per game trend")
     show_completion_rate: bool = Field(True, description="Display game completion rate")
-    show_enhanced_win_rates: bool = Field(True, description="Display win/loss/draw breakdown")
+    show_enhanced_win_rates: bool = Field(
+        True, description="Display win/loss/draw breakdown"
+    )
     show_turns_trend: bool = Field(True, description="Display average turns trend")
     metrics_window_size: int = Field(100, description="Rolling window size for metrics")
-    trend_smoothing_factor: float = Field(0.1, description="Smoothing factor for trend arrows")
+    trend_smoothing_factor: float = Field(
+        0.1, description="Smoothing factor for trend arrows"
+    )
     metrics_panel_height: int = Field(6, description="Height of metrics panel")
     enable_trendlines: bool = Field(True, description="Show trendlines in sparklines")
 

--- a/keisei/training/display.py
+++ b/keisei/training/display.py
@@ -59,7 +59,9 @@ class TrainingDisplay:
                 max_moves=self.display_config.move_list_length,
             )
             self.moves_component = RecentMovesPanel(
-                max_moves=self.display_config.move_list_length
+                max_moves=self.display_config.move_list_length,
+                newest_on_top=self.display_config.moves_latest_top,
+                flash_ms=self.display_config.moves_flash_ms,
             )
             self.piece_stand_component = PieceStandPanel()
         if self.display_config.enable_trend_visualization:
@@ -331,8 +333,14 @@ class TrainingDisplay:
                 move_strings = (
                     trainer.step_manager.move_log if trainer.step_manager else None
                 )
+                panel_height = self.layout["moves_panel"].size.height
+                pps = getattr(trainer, "last_ply_per_sec", 0.0)
                 self.layout["moves_panel"].update(
-                    self.moves_component.render(move_strings)
+                    self.moves_component.render(
+                        move_strings,
+                        available_height=panel_height,
+                        ply_per_sec=pps,
+                    )
                 )
 
             if self.trend_component:
@@ -361,7 +369,11 @@ class TrainingDisplay:
                         Panel,
                         self.game_stats_component.render(
                             trainer.game,
-                            trainer.step_manager.move_log if trainer.step_manager else None,
+                            (
+                                trainer.step_manager.move_log
+                                if trainer.step_manager
+                                else None
+                            ),
                             trainer.metrics_manager,
                         ),
                     )

--- a/keisei/training/display.py
+++ b/keisei/training/display.py
@@ -256,6 +256,7 @@ class TrainingDisplay:
 
         SPARKLINE_WIDTH = self.display_config.sparkline_width
         assert self.trend_component is not None
+        trend = self.trend_component
 
         for name, history_key in metrics_to_display:
             if history_key == "win_rates_black":
@@ -275,7 +276,7 @@ class TrainingDisplay:
             avg_val = sum(avg_slice) / len(avg_slice) if avg_slice else None
 
             spark = (
-                self.trend_component.generate(data_list[-SPARKLINE_WIDTH:])
+                trend.generate(data_list[-SPARKLINE_WIDTH:])
                 if data_list
                 else " " * SPARKLINE_WIDTH
             )
@@ -333,7 +334,9 @@ class TrainingDisplay:
                 move_strings = (
                     trainer.step_manager.move_log if trainer.step_manager else None
                 )
-                panel_height = self.layout["moves_panel"].size.height
+                panel_height = int(
+                    getattr(self.layout["moves_panel"].size, "height", 0)
+                )
                 pps = getattr(trainer, "last_ply_per_sec", 0.0)
                 self.layout["moves_panel"].update(
                     self.moves_component.render(
@@ -355,7 +358,7 @@ class TrainingDisplay:
                     BarColumn(bar_width=None),
                     TaskProgressColumn(),
                 )
-                grad_bar.add_task("", total=50.0, completed=grad_norm_scaled)
+                grad_bar.add_task("", total=50.0, completed=int(grad_norm_scaled))
                 group_items.append(grad_bar)
 
                 self.layout["trends_panel"].update(
@@ -365,6 +368,7 @@ class TrainingDisplay:
                 )
 
                 try:
+                    assert self.game_stats_component is not None
                     panel = cast(
                         Panel,
                         self.game_stats_component.render(
@@ -377,7 +381,7 @@ class TrainingDisplay:
                             trainer.metrics_manager,
                         ),
                     )
-                    group_stats = [panel.renderable]
+                    group_stats: List[RenderableType] = [panel.renderable]
                     try:
                         buffer_bar = Progress(
                             TextColumn("Replay Buffer"),

--- a/keisei/training/display.py
+++ b/keisei/training/display.py
@@ -2,7 +2,7 @@
 training/display.py: Rich UI management for the Shogi RL trainer.
 """
 
-from typing import List, Union, Optional, Dict
+from typing import List, Union, Optional, Dict, cast
 
 from rich.console import Console, Group, RenderableType
 from rich.table import Table
@@ -253,6 +253,7 @@ class TrainingDisplay:
         table.add_column("Trend", no_wrap=True, ratio=4)
 
         SPARKLINE_WIDTH = self.display_config.sparkline_width
+        assert self.trend_component is not None
 
         for name, history_key in metrics_to_display:
             if history_key == "win_rates_black":
@@ -356,11 +357,13 @@ class TrainingDisplay:
                 )
 
                 try:
-                    panel = self.game_stats_component.render(
-                        trainer.game,
-                        trainer.step_manager.move_log if trainer.step_manager else None,
-                        trainer.metrics_manager,
-                        trainer.policy_output_mapper,
+                    panel = cast(
+                        Panel,
+                        self.game_stats_component.render(
+                            trainer.game,
+                            trainer.step_manager.move_log if trainer.step_manager else None,
+                            trainer.metrics_manager,
+                        ),
                     )
                     group_stats = [panel.renderable]
                     try:
@@ -420,7 +423,7 @@ class TrainingDisplay:
 
             model = getattr(trainer.agent, "model", None)
             if model is not None:
-                stats_lines = []
+                stats_lines: List[RenderableType] = []
                 current_stats: Dict[str, Dict[str, float]] = {}
                 named_params = dict(model.named_parameters())
 

--- a/keisei/training/display.py
+++ b/keisei/training/display.py
@@ -162,12 +162,12 @@ class TrainingDisplay:
             TextColumn("• {task.fields[ep_metrics]}", style="bright_cyan"),
             TextColumn("• {task.fields[ppo_metrics]}", style="bright_yellow"),
             TextColumn(
-                "• Wins B:{task.fields[black_wins_cum]} W:{task.fields[white_wins_cum]} D:{task.fields[draws_cum]}",
+                "• Wins S:{task.fields[black_wins_cum]} G:{task.fields[white_wins_cum]} D:{task.fields[draws_cum]}",
                 style="bright_green",
             ),
             TextColumn(
-                "• Rates B:{task.fields[black_win_rate]:.1%} "
-                "W:{task.fields[white_win_rate]:.1%} "
+                "• Rates S:{task.fields[black_win_rate]:.1%} "
+                "G:{task.fields[white_win_rate]:.1%} "
                 "D:{task.fields[draw_rate]:.1%}",
                 style="bright_blue",
             ),
@@ -256,9 +256,13 @@ class TrainingDisplay:
 
         for name, history_key in metrics_to_display:
             if history_key == "win_rates_black":
-                data_list = [d.get("win_rate_black", 0.0) for d in history.win_rates_history]
+                data_list = [
+                    d.get("win_rate_black", 0.0) for d in history.win_rates_history
+                ]
             elif history_key == "draw_rates":
-                data_list = [d.get("win_rate_draw", 0.0) for d in history.win_rates_history]
+                data_list = [
+                    d.get("win_rate_draw", 0.0) for d in history.win_rates_history
+                ]
             else:
                 data_list = getattr(history, history_key, [])
 
@@ -299,8 +303,11 @@ class TrainingDisplay:
         if self.using_enhanced_layout:
             if self.board_component:
                 try:
+                    hot_sq = trainer.metrics_manager.get_hot_squares(top_n=3)
                     self.layout["board_panel"].update(
-                        self.board_component.render(trainer.game)
+                        self.board_component.render(
+                            trainer.game, highlight_squares=hot_sq
+                        )
                     )
                 except Exception as e:
                     self.rich_console.log(
@@ -363,12 +370,18 @@ class TrainingDisplay:
                             TextColumn("{task.percentage:>3.0f}%"),
                         )
                         buf = trainer.experience_buffer
-                        buffer_bar.add_task("", total=buf.capacity(), completed=buf.size())
+                        buffer_bar.add_task(
+                            "", total=buf.capacity(), completed=buf.size()
+                        )
                         group_stats.append(buffer_bar)
                     except Exception:
                         pass
                     self.layout["stats_panel"].update(
-                        Panel(Group(*group_stats), title="Game Statistics", border_style="green")
+                        Panel(
+                            Group(*group_stats),
+                            title="Game Statistics",
+                            border_style="green",
+                        )
                     )
                 except Exception as e:
                     self.layout["stats_panel"].update(
@@ -385,7 +398,9 @@ class TrainingDisplay:
                     config_table = Table.grid(padding=(0, 2))
                     config_table.add_column(style="bold")
                     config_table.add_column()
-                    config_table.add_row("Learning Rate:", str(cfg.training.learning_rate))
+                    config_table.add_row(
+                        "Learning Rate:", str(cfg.training.learning_rate)
+                    )
                     config_table.add_row("Batch Size:", str(batch_size))
                     config_table.add_row("Tower Depth:", str(cfg.training.tower_depth))
                     config_table.add_row("SE Ratio:", str(cfg.training.se_ratio))
@@ -459,7 +474,8 @@ class TrainingDisplay:
                 self.previous_model_stats = current_stats
 
                 arch = Text(
-                    "[Input: 9x9xN] -> [ResNet Core] -> [Policy Head]\n" "                         -> [Value Head]",
+                    "[Input: 9x9xN] -> [ResNet Core] -> [Policy Head]\n"
+                    "                         -> [Value Head]",
                     style="bold",
                 )
                 self.layout["evolution_panel"].update(

--- a/keisei/training/display_components.py
+++ b/keisei/training/display_components.py
@@ -236,7 +236,7 @@ class RecentMovesPanel:
             if ply_per_sec
             else f"Recent Moves ({len(moves)})"
         )
-        return Panel(body, title=title, border_style="yellow")
+        return Panel(body, title=title, border_style="yellow", expand=True)
 
 
 class PieceStandPanel:

--- a/keisei/training/display_components.py
+++ b/keisei/training/display_components.py
@@ -6,12 +6,14 @@ from typing import Protocol, Optional, List, Sequence, Dict
 from collections import deque, Counter
 import ast
 from wcwidth import wcswidth
+from keisei.utils import _coords_to_square_name
 
 from keisei.utils.unified_logger import log_error_to_stderr
 from keisei.shogi.shogi_core_definitions import Color
 
 from rich.console import RenderableType, Group
 from rich.panel import Panel
+from rich import box
 from rich.text import Text
 from rich.layout import Layout
 from rich.table import Table
@@ -116,7 +118,10 @@ class ShogiBoard:
         padding = self.cell_width - width
         return symbol + (" " * padding)
 
-    def _generate_rich_table(self, board_state) -> Table:
+    def _get_shogi_notation(self, row: int, col: int) -> str:
+        return _coords_to_square_name(row, col)
+
+    def _generate_rich_table(self, board_state, hot_squares=None) -> Table:
         """Create a 10×10 Table for the board."""
         light_bg_color = "#EEC28A"
         dark_bg_color = "#C19A55"
@@ -161,17 +166,35 @@ class ShogiBoard:
                     cell_renderable = Text(padded, style=dot_color)
 
                 cell_renderable.stylize(bg_style)
+
+                board_col = 8 - c_idx
+                sq_name = self._get_shogi_notation(r_idx, board_col)
+                if hot_squares and sq_name in hot_squares:
+                    cell_renderable = Panel(
+                        Align.center(cell_renderable),
+                        box=box.SQUARE,
+                        padding=(0, 0),
+                        border_style="red",
+                        width=self.cell_width + 2,
+                    )
+
                 row_cells.append(cell_renderable)
 
             table.add_row(*row_cells)
         return table
 
-    def render(self, board_state=None, **_kwargs) -> RenderableType:
+    def render(
+        self, board_state=None, highlight_squares=None, **_kwargs
+    ) -> RenderableType:
         """Returns a Panel containing a Rich Table of the current board."""
         if not board_state:
-            return Panel(Text("No active game"), title="Main Board", border_style="blue")
+            return Panel(
+                Text("No active game"), title="Main Board", border_style="blue"
+            )
 
-        board_table = self._generate_rich_table(board_state)
+        board_table = self._generate_rich_table(
+            board_state, hot_squares=highlight_squares
+        )
         return Panel(Align.center(board_table), title="Main Board", border_style="blue")
 
 
@@ -213,15 +236,23 @@ class PieceStandPanel:
             "BISHOP": "角",
             "ROOK": "飛",
         }
-        parts = [f"{symbols.get(getattr(k, 'name', k), '?')}x{v}" for k, v in hand.items() if v > 0]
+        parts = [
+            f"{symbols.get(getattr(k, 'name', k), '?')}x{v}"
+            for k, v in hand.items()
+            if v > 0
+        ]
         return " ".join(parts) or ""
 
     def render(self, game) -> RenderableType:
         if not game:
             return Panel("...", title="Captured Pieces")
 
-        sente_hand = self._format_hand(getattr(game, "hands", {}).get(Color.BLACK.value, {}))
-        gote_hand = self._format_hand(getattr(game, "hands", {}).get(Color.WHITE.value, {}))
+        sente_hand = self._format_hand(
+            getattr(game, "hands", {}).get(Color.BLACK.value, {})
+        )
+        gote_hand = self._format_hand(
+            getattr(game, "hands", {}).get(Color.WHITE.value, {})
+        )
 
         return Panel(
             Group(
@@ -336,71 +367,56 @@ class GameStatisticsPanel:
         game,
         move_history: Optional[List[str]] = None,
         metrics_manager=None,
-        policy_mapper=None,
     ) -> RenderableType:
-        if (
-            not game
-            or move_history is None
-            or metrics_manager is None
-            or policy_mapper is None
-        ):
+        if not game or not move_history or not metrics_manager:
             return Panel(
                 "Waiting for game to start...",
                 title="Game Statistics",
                 border_style="green",
             )
 
-        sente_material = self._calculate_material(game, Color.BLACK)
-        gote_material = self._calculate_material(game, Color.WHITE)
+        # --- Calculate In-Game Stats ---
+        sente_material = self._calculate_material(game.board, Color.BLACK)
+        gote_material = self._calculate_material(game.board, Color.WHITE)
         material_adv = sente_material - gote_material
+        is_in_check = getattr(game, "is_in_check", lambda: False)()
+        hot_squares = metrics_manager.get_hot_squares(top_n=3)
 
-        square_usage = Counter()
-        for move in move_history:
-            try:
-                parts = move.split(" from ")[1].split(" to ")
-                square_usage.update([parts[0], parts[1].strip(".")])
-            except IndexError:
-                continue
-        hot_squares = ", ".join([sq[0] for sq in square_usage.most_common(3)]) or "N/A"
-
+        # --- Get Session Stats (now pre-formatted) ---
         sente_openings = metrics_manager.sente_opening_history
         gote_openings = metrics_manager.gote_opening_history
-        fav_sente_tuple = (
-            Counter(sente_openings).most_common(1)[0][0] if sente_openings else None
+        fav_sente_opening = (
+            Counter(sente_openings).most_common(1)[0][0] if sente_openings else "N/A"
         )
-        fav_gote_tuple = (
-            Counter(gote_openings).most_common(1)[0][0] if gote_openings else None
+        fav_gote_opening = (
+            Counter(gote_openings).most_common(1)[0][0] if gote_openings else "N/A"
         )
 
-        try:
-            fav_sente_opening = (
-                policy_mapper.shogi_move_to_usi(ast.literal_eval(fav_sente_tuple))
-                if fav_sente_tuple
-                else "N/A"
-            )
-        except Exception:
-            fav_sente_opening = "N/A"
-
-        try:
-            fav_gote_opening = (
-                policy_mapper.shogi_move_to_usi(ast.literal_eval(fav_gote_tuple))
-                if fav_gote_tuple
-                else "N/A"
-            )
-        except Exception:
-            fav_gote_opening = "N/A"
-
+        # --- Create Table ---
         table = Table.grid(expand=True, padding=(0, 2))
         table.add_column(style="bold cyan", no_wrap=True)
-        table.add_column(justify="right")
+        table.add_column()
 
-        check_status = (
-            "[red]CHECK[/]" if game.is_in_check(game.current_player) else "Clear"
-        )
-        table.add_row("Check Status:", check_status)
+        table.add_row("Check Status:", "[red]CHECK[/]" if is_in_check else "Clear")
         table.add_row("Material Adv:", f"{material_adv:+.1f} (Sente)")
-        table.add_row("Hot Squares:", hot_squares)
+        table.add_row("Hot Squares:", ", ".join(hot_squares) or "N/A")
         table.add_row("Fav. Sente Opening:", fav_sente_opening)
         table.add_row("Fav. Gote Opening:", fav_gote_opening)
 
-        return Panel(table, title="Game Statistics", border_style="green")
+        # This part for hand display remains separate to preserve alignment
+        sente_hand_str = self._format_hand(
+            getattr(game, "hands", {}).get(Color.BLACK, {})
+        )
+        gote_hand_str = self._format_hand(
+            getattr(game, "hands", {}).get(Color.WHITE, {})
+        )
+        hand_info = Group(
+            Text.from_markup("\n[bold]Sente's Hand:[/bold]"),
+            Text(sente_hand_str or "None"),
+            Text.from_markup("\n[bold]Gote's Hand:[/bold]"),
+            Text(gote_hand_str or "None"),
+        )
+
+        return Panel(
+            Group(table, hand_info), title="Game Statistics", border_style="green"
+        )

--- a/keisei/training/metrics_manager.py
+++ b/keisei/training/metrics_manager.py
@@ -6,7 +6,7 @@ import json
 import time
 from collections import deque, Counter
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple, List, Deque
+from typing import Any, Dict, Optional, Tuple, List, Deque, Sequence
 
 from keisei.utils import (
     _coords_to_square_name,
@@ -206,8 +206,8 @@ class MetricsManager:
             except Exception:
                 pass
 
-    def get_moves_per_game_trend(self, window_size: int = 100) -> List[float]:
-        data = list(self.moves_per_game)[-window_size:]
+    def get_moves_per_game_trend(self, window_size: int = 100) -> Sequence[int]:
+        data: List[int] = list(self.moves_per_game)[-window_size:]
         return data
 
     def get_hot_squares(self, top_n: int = 3) -> List[str]:
@@ -229,8 +229,8 @@ class MetricsManager:
         draws = sum(1 for r, _ in recent if r == "draw")
         return {"win": wins / total, "loss": losses / total, "draw": draws / total}
 
-    def get_average_turns_trend(self, window_size: int = 100) -> List[float]:
-        data = list(self.turns_per_game)[-window_size:]
+    def get_average_turns_trend(self, window_size: int = 100) -> Sequence[int]:
+        data: List[int] = list(self.turns_per_game)[-window_size:]
         return data
 
     def format_episode_metrics(self, episode_length: int, episode_reward: float) -> str:

--- a/keisei/training/parallel/utils.py
+++ b/keisei/training/parallel/utils.py
@@ -12,7 +12,9 @@ def compress_array(array: np.ndarray) -> Dict[str, Any]:
         original_size = len(array_bytes)
         compressed_bytes = gzip.compress(array_bytes, compresslevel=6)
         compressed_size = len(compressed_bytes)
-        compression_ratio = original_size / compressed_size if compressed_size > 0 else 1.0
+        compression_ratio = (
+            original_size / compressed_size if compressed_size > 0 else 1.0
+        )
         return {
             "data": compressed_bytes,
             "shape": array.shape,
@@ -48,4 +50,5 @@ def decompress_array(data: Dict[str, Any]) -> np.ndarray:
     except Exception as e:
         # Log the exception for debugging purposes
         logging.error("Decompression failed. Returning raw data.", exc_info=True)
-        return data.get("data")
+        # Fall back to returning the raw data as a numpy array
+        return np.asarray(data["data"])

--- a/keisei/training/step_manager.py
+++ b/keisei/training/step_manager.py
@@ -509,11 +509,12 @@ class StepManager:
             piece_info_for_demo,
         )
 
-        player_display = (
-            current_player_name.title()
-            if current_player_name.upper() in {"BLACK", "WHITE"}
-            else current_player_name
-        )
+        if current_player_name.upper() == "BLACK":
+            player_display = "Sente"
+        elif current_player_name.upper() == "WHITE":
+            player_display = "Gote"
+        else:
+            player_display = current_player_name
         log_msg = f"Move {episode_length + 1} ({player_display}): {move_str}"
         self.move_log.append(log_msg)
         self.move_history.append(selected_move)
@@ -549,9 +550,9 @@ class StepManager:
     def _format_game_outcome_message(self, winner: Optional[str], reason: str) -> str:
         """Helper to format the game outcome message."""
         if winner == "black":
-            return f"Black wins by {reason}."
+            return f"Sente wins by {reason}."
         if winner == "white":
-            return f"White wins by {reason}."
+            return f"Gote wins by {reason}."
         if winner is None:
             return f"Draw by {reason}."
         return f"Game ended: {winner} by {reason}."  # Should ideally not be reached with current logic

--- a/keisei/training/training_loop_manager.py
+++ b/keisei/training/training_loop_manager.py
@@ -383,7 +383,12 @@ class TrainingLoopManager:
             turns_count,
             result,
             ep_rew,
-            self.trainer.step_manager.move_history if self.trainer.step_manager else None,
+            (
+                self.trainer.step_manager.move_history
+                if self.trainer.step_manager
+                else None
+            ),
+            self.trainer.policy_output_mapper,
         )
 
         total_games = (

--- a/keisei/utils/profiling.py
+++ b/keisei/utils/profiling.py
@@ -258,7 +258,7 @@ def memory_usage_mb() -> float:
     try:
         import os
 
-        import psutil
+        import psutil  # type: ignore[import]
 
         process = psutil.Process(os.getpid())
         return process.memory_info().rss / 1024 / 1024  # Convert to MB

--- a/keisei/utils/utils.py
+++ b/keisei/utils/utils.py
@@ -22,7 +22,7 @@ from typing import (
 )
 
 import torch
-import yaml
+import yaml  # type: ignore[import]
 from pydantic import ValidationError
 from rich.console import Console
 from rich.text import Text
@@ -34,7 +34,10 @@ from keisei.shogi.shogi_core_definitions import (
     PieceType,
     get_unpromoted_types,
 )
-from keisei.utils.unified_logger import log_error_to_stderr
+from keisei.utils.unified_logger import (
+    log_error_to_stderr,
+    log_info_to_stderr,
+)
 
 # --- Config Loader Utility ---
 
@@ -519,9 +522,7 @@ class TrainingLogger:
             rich_message = Text(full_message)
             self.rich_log_panel.append(rich_message)
             # The Live display will handle the update. We don't print directly here.
-        elif (
-            self.also_stdout_if_no_rich
-        ):
+        elif self.also_stdout_if_no_rich:
             # Fallback to stdout if rich components are not provided
             try:
                 log_info_to_stderr("TrainingLogger", full_message)

--- a/tests/test_display_infrastructure.py
+++ b/tests/test_display_infrastructure.py
@@ -27,13 +27,14 @@ def test_metrics_history_trimming():
     assert len(history.win_rates_history) == 3
 
     for i in range(5):
-        history.add_ppo_data({
-            "ppo/learning_rate": float(i),
-            "ppo/policy_loss": float(i),
-        })
+        history.add_ppo_data(
+            {
+                "ppo/learning_rate": float(i),
+                "ppo/policy_loss": float(i),
+            }
+        )
     assert len(history.learning_rates) == 3
     assert len(history.policy_losses) == 3
-
 
 
 def test_elo_rating_updates():
@@ -47,7 +48,6 @@ def test_sparkline_generation():
     spark = Sparkline(width=5)
     s = spark.generate([1, 2, 3, 4, 5])
     assert len(s) == 5
-
 
 
 def test_adaptive_layout_choice():
@@ -71,7 +71,7 @@ def test_shogi_board_basic_render():
 
 
 def test_recent_moves_panel_render():
-    panel = RecentMovesPanel(max_moves=2)
+    panel = RecentMovesPanel(max_moves=2, newest_on_top=True, flash_ms=0)
     moves = ["7g7f", "8c8d", "2g2f"]
-    rendered = panel.render(moves)
+    rendered = panel.render(moves, available_height=5)
     assert "8c8d" in rendered.renderable.plain

--- a/tests/test_step_manager.py
+++ b/tests/test_step_manager.py
@@ -476,7 +476,7 @@ class TestHandleEpisodeEnd:
         mock_logger.assert_called()
         log_message = mock_logger.call_args[0][0]
         assert "Episode 18 finished" in log_message
-        assert "Black wins by checkmate" in log_message
+        assert "Sente wins by checkmate" in log_message
 
         # Verify wandb data was logged
         wandb_data = mock_logger.call_args[1]["wandb_data"]
@@ -513,7 +513,7 @@ class TestHandleEpisodeEnd:
 
         # Verify white win message
         log_message = mock_logger.call_args[0][0]
-        assert "White wins by timeout" in log_message
+        assert "Gote wins by timeout" in log_message
 
     def test_episode_end_draw(
         self, step_manager, sample_episode_state, mock_logger, mock_components


### PR DESCRIPTION
## Summary
- track square usage and formatted opening moves in `MetricsManager`
- highlight hot squares on the main board
- simplify `GameStatisticsPanel.render` and show favourite openings
- update progress bar and move logs to use Sente/Gote terminology
- pass hot square info to board rendering

## Testing
- `pytest -q tests/test_metrics_manager.py tests/test_move_formatting.py`


------
https://chatgpt.com/codex/tasks/task_e_684454b30b48832391656fd418ab5171