### PR TITLE
Low-hanging-fruit bug fixes: W5 gauntlet unpack, W1 atomic result, W11b SL lambda validation

### DIFF
--- a/keisei/sl/trainer.py
+++ b/keisei/sl/trainer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -40,6 +41,17 @@ class SLConfig:
             raise ValueError(f"learning_rate must be > 0, got {self.learning_rate}")
         if self.num_workers < 0:
             raise ValueError(f"num_workers must be >= 0, got {self.num_workers}")
+        # keisei-678359b7aa: each lambda must be a finite, non-negative number.
+        # Zero is legitimate (disables a head); negative values silently invert
+        # the optimisation direction (gradient ascent) for that head, and
+        # NaN/inf would poison the combined loss. MultiHeadValueAdapter (RL)
+        # enforces the same contract.
+        for name in ("lambda_policy", "lambda_value", "lambda_score"):
+            value = getattr(self, name)
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite, got {value!r}")
+            if value < 0:
+                raise ValueError(f"{name} must be >= 0, got {value!r}")
 
 
 logger = logging.getLogger(__name__)

--- a/keisei/training/historical_gauntlet.py
+++ b/keisei/training/historical_gauntlet.py
@@ -147,7 +147,7 @@ class HistoricalGauntlet:
                     continue
 
                 try:
-                    wins, losses, draws = play_match(
+                    outcome = play_match(
                         vecenv, learner_model, hist_model,
                         device=self.device, num_envs=effective_num_envs,
                         max_ply=self.max_ply, games_target=self.config.games_per_matchup,
@@ -162,6 +162,7 @@ class HistoricalGauntlet:
                 finally:
                     release_models(hist_model, device_type=self.device.type)
 
+                wins, losses, draws = outcome.a_wins, outcome.b_wins, outcome.draws
                 game_count = wins + losses + draws
                 if game_count == 0:
                     continue

--- a/keisei/training/tournament.py
+++ b/keisei/training/tournament.py
@@ -410,29 +410,36 @@ class LeagueTournament:
             elo_before_b = current_b.elo_rating
             role_new_a = new_a_elo
             role_new_b = new_b_elo
-        self.store.record_result(
-            epoch=epoch,
-            entry_a_id=entry_a_id,
-            entry_b_id=entry_b_id,
-            wins_a=a_wins,
-            wins_b=b_wins,
-            draws=draws,
-            match_type="train" if is_train else "calibration",
-            role_a=current_a.role,
-            role_b=current_b.role,
-            elo_before_a=elo_before_a,
-            elo_after_a=role_new_a,
-            elo_before_b=elo_before_b,
-            elo_after_b=role_new_b,
-            training_updates_a=current_a.update_count,
-            training_updates_b=current_b.update_count,
-        )
-        self.store.update_elo(entry_a_id, new_a_elo, epoch=epoch)
-        self.store.update_elo(entry_b_id, new_b_elo, epoch=epoch)
-        if self.role_elo_tracker:
-            self.role_elo_tracker.update_from_result(
-                current_a, current_b, result_score, context,
+        # keisei-fa604bad63: wrap result + composite Elo + role Elo in one
+        # transaction so a crash between writes cannot leave a recorded match
+        # with partially-applied ratings. transaction() is reentrant — the
+        # nested transactions inside record_result/update_elo/update_role_elo
+        # see _transaction_depth > 1 and skip commit/rollback, so only this
+        # outer block decides atomicity.
+        with self.store.transaction():
+            self.store.record_result(
+                epoch=epoch,
+                entry_a_id=entry_a_id,
+                entry_b_id=entry_b_id,
+                wins_a=a_wins,
+                wins_b=b_wins,
+                draws=draws,
+                match_type="train" if is_train else "calibration",
+                role_a=current_a.role,
+                role_b=current_b.role,
+                elo_before_a=elo_before_a,
+                elo_after_a=role_new_a,
+                elo_before_b=elo_before_b,
+                elo_after_b=role_new_b,
+                training_updates_a=current_a.update_count,
+                training_updates_b=current_b.update_count,
             )
+            self.store.update_elo(entry_a_id, new_a_elo, epoch=epoch)
+            self.store.update_elo(entry_b_id, new_b_elo, epoch=epoch)
+            if self.role_elo_tracker:
+                self.role_elo_tracker.update_from_result(
+                    current_a, current_b, result_score, context,
+                )
         logger.info(
             "  %s vs %s — %dW %dL %dD",
             current_a.display_name, current_b.display_name,

--- a/tests/test_historical_gauntlet.py
+++ b/tests/test_historical_gauntlet.py
@@ -11,6 +11,7 @@ from keisei.config import GauntletConfig, RoleEloConfig
 from keisei.db import init_db
 from keisei.training.historical_gauntlet import HistoricalGauntlet
 from keisei.training.historical_library import HistoricalSlot
+from keisei.training.match_utils import MatchOutcome
 from keisei.training.opponent_store import EloColumn, OpponentStore, Role
 from keisei.training.role_elo import RoleEloTracker
 
@@ -203,7 +204,7 @@ class TestStaleEloAccumulation:
 
         with (
             patch.object(store, "load_opponent", return_value=dummy_model),
-            patch("keisei.training.historical_gauntlet.play_match", return_value=(16, 0, 0)),
+            patch("keisei.training.historical_gauntlet.play_match", return_value=MatchOutcome(16, 0, 0)),
             patch("keisei.training.historical_gauntlet.release_models"),
         ):
             gauntlet.run_gauntlet(epoch=100, learner_entry=learner, historical_slots=slots, vecenv=dummy_vecenv)
@@ -290,7 +291,7 @@ class TestRunGauntletFailurePaths:
 
         with (
             patch.object(store, "load_opponent", side_effect=selective_load),
-            patch("keisei.training.historical_gauntlet.play_match", return_value=(8, 4, 4)),
+            patch("keisei.training.historical_gauntlet.play_match", return_value=MatchOutcome(8, 4, 4)),
             patch("keisei.training.historical_gauntlet.release_models"),
         ):
             gauntlet.run_gauntlet(epoch=100, learner_entry=learner, historical_slots=slots, vecenv=dummy_vecenv)
@@ -317,7 +318,7 @@ class TestRunGauntletFailurePaths:
 
         with (
             patch.object(store, "load_opponent", return_value=dummy_model),
-            patch("keisei.training.historical_gauntlet.play_match", return_value=(0, 0, 0)),
+            patch("keisei.training.historical_gauntlet.play_match", return_value=MatchOutcome(0, 0, 0)),
             patch("keisei.training.historical_gauntlet.release_models"),
         ):
             gauntlet.run_gauntlet(epoch=100, learner_entry=learner, historical_slots=slots, vecenv=dummy_vecenv)
@@ -346,7 +347,7 @@ class TestRunGauntletFailurePaths:
 
         with (
             patch.object(store, "load_opponent", return_value=dummy_model),
-            patch("keisei.training.historical_gauntlet.play_match", return_value=(10, 2, 4)),
+            patch("keisei.training.historical_gauntlet.play_match", return_value=MatchOutcome(10, 2, 4)),
             patch("keisei.training.historical_gauntlet.release_models"),
         ):
             gauntlet.run_gauntlet(epoch=100, learner_entry=learner, historical_slots=slots, vecenv=dummy_vecenv)
@@ -356,3 +357,92 @@ class TestRunGauntletFailurePaths:
             rows = store._conn.execute("SELECT * FROM gauntlet_results").fetchall()
             assert len(rows) == 1
             assert dict(rows[0])["historical_slot"] == 1
+
+
+class TestMatchOutcomeUnpacking:
+    """Regression for keisei-4509042dd1: production play_match returns MatchOutcome.
+
+    Earlier tests patched play_match to return raw tuples, masking the bug
+    that the gauntlet was tuple-unpacking a dataclass with no __iter__.
+    These tests use real MatchOutcome instances to prove the call site
+    handles the actual production return type.
+    """
+
+    def test_real_match_outcome_records_wins(self, gauntlet_setup):
+        """A real MatchOutcome (not a tuple) must yield a recorded gauntlet result."""
+        gauntlet, store, _ = gauntlet_setup
+        model = torch.nn.Linear(10, 10)
+        learner = store.add_entry(model, "resnet", {}, epoch=1, role=Role.DYNAMIC)
+        hist = store.add_entry(model, "resnet", {}, epoch=50, role=Role.RECENT_FIXED)
+        store.retire_entry(hist.id, "archive")
+
+        slots = [
+            HistoricalSlot(0, target_epoch=50, entry_id=hist.id, actual_epoch=50, selection_mode="log_spaced"),
+        ]
+
+        dummy_model = object()
+        dummy_vecenv = object()
+
+        # Always-win opponent: 16W 0L 0D as a real MatchOutcome dataclass.
+        with (
+            patch.object(store, "load_opponent", return_value=dummy_model),
+            patch(
+                "keisei.training.historical_gauntlet.play_match",
+                return_value=MatchOutcome(a_wins=16, b_wins=0, draws=0),
+            ),
+            patch("keisei.training.historical_gauntlet.release_models"),
+        ):
+            gauntlet.run_gauntlet(
+                epoch=100, learner_entry=learner,
+                historical_slots=slots, vecenv=dummy_vecenv,
+            )
+
+        with store._lock:
+            row = store._conn.execute(
+                "SELECT wins, losses, draws, elo_before, elo_after "
+                "FROM gauntlet_results"
+            ).fetchone()
+
+        assert row is not None, (
+            "Gauntlet failed to record any result — MatchOutcome unpacking regressed"
+        )
+        assert row["wins"] == 16
+        assert row["losses"] == 0
+        assert row["draws"] == 0
+        assert row["elo_after"] > row["elo_before"], "Always-win must raise Elo"
+
+    def test_match_outcome_with_rollout_field_is_unpacked(self, gauntlet_setup):
+        """MatchOutcome's optional rollout field must not break the unpack."""
+        gauntlet, store, _ = gauntlet_setup
+        model = torch.nn.Linear(10, 10)
+        learner = store.add_entry(model, "resnet", {}, epoch=1, role=Role.DYNAMIC)
+        hist = store.add_entry(model, "resnet", {}, epoch=50, role=Role.RECENT_FIXED)
+
+        slots = [
+            HistoricalSlot(0, target_epoch=50, entry_id=hist.id, actual_epoch=50, selection_mode="log_spaced"),
+        ]
+
+        dummy_model = object()
+        dummy_vecenv = object()
+
+        # rollout defaults to None — confirm production-shaped MatchOutcome unpacks.
+        outcome = MatchOutcome(a_wins=4, b_wins=8, draws=4)
+        assert outcome.rollout is None  # sanity: matches production default
+
+        with (
+            patch.object(store, "load_opponent", return_value=dummy_model),
+            patch("keisei.training.historical_gauntlet.play_match", return_value=outcome),
+            patch("keisei.training.historical_gauntlet.release_models"),
+        ):
+            gauntlet.run_gauntlet(
+                epoch=100, learner_entry=learner,
+                historical_slots=slots, vecenv=dummy_vecenv,
+            )
+
+        with store._lock:
+            row = store._conn.execute(
+                "SELECT wins, losses, draws FROM gauntlet_results"
+            ).fetchone()
+
+        assert row is not None
+        assert (row["wins"], row["losses"], row["draws"]) == (4, 8, 4)

--- a/tests/test_league_tournament.py
+++ b/tests/test_league_tournament.py
@@ -773,3 +773,149 @@ class TestPlayMatchModelCleanup:
             assert fake_model in args[0], (
                 "release_models should include the successfully-loaded model_a"
             )
+
+
+# ===========================================================================
+# Regression: keisei-fa604bad63 — atomic _record_match_result
+# ===========================================================================
+
+
+class TestRecordMatchResultAtomicity:
+    """Failure mid-write must roll back: no half-applied Elo, no orphan results.
+
+    Background: _record_match_result issues four writes (record_result, two
+    update_elo, role_elo update_from_result). Pre-fix each was its own
+    transaction, so a crash between writes left the DB with a recorded match
+    pointing at stale ratings — corrupting Elo trajectories silently.
+    Post-fix everything is wrapped in a single store.transaction() block.
+    """
+
+    def test_failure_on_second_update_elo_rolls_back_everything(
+        self, store, tournament_db,
+    ):
+        """Inject failure on entry_b's update_elo — confirm nothing partial persists."""
+        import torch
+
+        # Real entries via store.add_entry so all columns (status, role) are set.
+        model = torch.nn.Linear(8, 8)
+        entry_a = store.add_entry(
+            model, "resnet", {}, epoch=1, role=Role.DYNAMIC,
+        )
+        entry_b = store.add_entry(
+            model, "resnet", {}, epoch=2, role=Role.DYNAMIC,
+        )
+        original_elo_a = entry_a.elo_rating
+        original_elo_b = entry_b.elo_rating
+
+        tournament = _make_tournament(store)
+
+        # Patch update_elo: succeed for entry_a (id=1), raise for entry_b (id=2).
+        real_update_elo = store.update_elo
+        call_log: list[int] = []
+
+        def flaky_update_elo(entry_id: int, new_elo: float, epoch: int = 0) -> None:
+            call_log.append(entry_id)
+            if entry_id == entry_b.id:
+                raise sqlite3.OperationalError(
+                    "simulated DB failure on second Elo update",
+                )
+            real_update_elo(entry_id, new_elo, epoch=epoch)
+
+        with patch.object(store, "update_elo", side_effect=flaky_update_elo):
+            with pytest.raises(sqlite3.OperationalError, match="simulated DB failure"):
+                tournament._record_match_result(
+                    epoch=5,
+                    entry_a_id=entry_a.id,
+                    entry_b_id=entry_b.id,
+                    a_wins=10, b_wins=0, draws=0,
+                    rollout=None,
+                )
+
+        # Confirm the injected fault actually fired (both attempts ran).
+        assert call_log == [entry_a.id, entry_b.id], (
+            f"expected update_elo called for A then B, got {call_log}"
+        )
+
+        # ── Assert no partial state survived ──
+        check_conn = sqlite3.connect(tournament_db)
+        check_conn.row_factory = sqlite3.Row
+
+        # 1. league_results: no row for this match
+        rows = check_conn.execute(
+            "SELECT COUNT(*) AS n FROM league_results WHERE epoch = ?", (5,),
+        ).fetchone()
+        assert rows["n"] == 0, "record_result must roll back on failure"
+
+        # 2. elo_history: no rows at this epoch (update_elo writes elo_history)
+        rows = check_conn.execute(
+            "SELECT COUNT(*) AS n FROM elo_history WHERE epoch = ?", (5,),
+        ).fetchone()
+        assert rows["n"] == 0, "first update_elo's elo_history insert must roll back"
+
+        # 3. league_entries: original Elo ratings unchanged for both players
+        a_now = check_conn.execute(
+            "SELECT elo_rating FROM league_entries WHERE id = ?", (entry_a.id,),
+        ).fetchone()
+        b_now = check_conn.execute(
+            "SELECT elo_rating FROM league_entries WHERE id = ?", (entry_b.id,),
+        ).fetchone()
+        assert a_now["elo_rating"] == pytest.approx(original_elo_a), (
+            f"entry A Elo changed despite rollback: {a_now['elo_rating']} != {original_elo_a}"
+        )
+        assert b_now["elo_rating"] == pytest.approx(original_elo_b)
+
+        # 4. games_played: no increment (record_result rolled back)
+        a_games = check_conn.execute(
+            "SELECT games_played FROM league_entries WHERE id = ?", (entry_a.id,),
+        ).fetchone()
+        assert a_games["games_played"] == 0
+        check_conn.close()
+
+    def test_happy_path_still_commits(self, store, tournament_db):
+        """Sanity: with no injected failure, all four writes land normally."""
+        import torch
+
+        model = torch.nn.Linear(8, 8)
+        entry_a = store.add_entry(
+            model, "resnet", {}, epoch=1, role=Role.DYNAMIC,
+        )
+        entry_b = store.add_entry(
+            model, "resnet", {}, epoch=2, role=Role.DYNAMIC,
+        )
+
+        tournament = _make_tournament(store)
+        recorded = tournament._record_match_result(
+            epoch=7,
+            entry_a_id=entry_a.id,
+            entry_b_id=entry_b.id,
+            a_wins=8, b_wins=2, draws=2,
+            rollout=None,
+        )
+        assert recorded is True
+
+        check_conn = sqlite3.connect(tournament_db)
+        check_conn.row_factory = sqlite3.Row
+
+        # league_results row exists
+        row = check_conn.execute(
+            "SELECT wins_a, wins_b, draws FROM league_results WHERE epoch = ?", (7,),
+        ).fetchone()
+        assert row is not None
+        assert (row["wins_a"], row["wins_b"], row["draws"]) == (8, 2, 2)
+
+        # elo_history rows for both entries at epoch 7
+        n_hist = check_conn.execute(
+            "SELECT COUNT(*) AS n FROM elo_history WHERE epoch = ?", (7,),
+        ).fetchone()["n"]
+        assert n_hist == 2
+
+        # Elo moved on both league_entries
+        a_now = check_conn.execute(
+            "SELECT elo_rating FROM league_entries WHERE id = ?", (entry_a.id,),
+        ).fetchone()["elo_rating"]
+        b_now = check_conn.execute(
+            "SELECT elo_rating FROM league_entries WHERE id = ?", (entry_b.id,),
+        ).fetchone()["elo_rating"]
+        assert a_now > 1000.0, "winner's Elo should rise"
+        assert b_now < 1000.0, "loser's Elo should fall"
+        check_conn.close()

--- a/tests/test_sl_config.py
+++ b/tests/test_sl_config.py
@@ -1,0 +1,85 @@
+"""Validation tests for SLConfig.__post_init__.
+
+Regression for keisei-678359b7aa: SLConfig accepted negative lambda_policy /
+lambda_value / lambda_score, which silently inverts gradient descent into
+gradient ascent for that loss component while per-head metrics still look
+positive.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from keisei.sl.trainer import SLConfig
+
+
+def _config(**overrides: object) -> SLConfig:
+    base = dict(data_dir="/tmp/unused")  # noqa: S108 — config validation only
+    base.update(overrides)
+    return SLConfig(**base)  # type: ignore[arg-type]
+
+
+class TestSLConfigLambdaValidation:
+    def test_defaults_accepted(self) -> None:
+        cfg = _config()
+        assert cfg.lambda_policy == 1.0
+        assert cfg.lambda_value == 1.5
+        assert cfg.lambda_score == 0.02
+
+    @pytest.mark.parametrize("field", ["lambda_policy", "lambda_value", "lambda_score"])
+    def test_zero_is_legitimate(self, field: str) -> None:
+        """Zero disables a head — must remain valid for ablations."""
+        cfg = _config(**{field: 0.0})
+        assert getattr(cfg, field) == 0.0
+
+    @pytest.mark.parametrize("field", ["lambda_policy", "lambda_value", "lambda_score"])
+    def test_negative_rejected(self, field: str) -> None:
+        with pytest.raises(ValueError, match=f"{field} must be >= 0"):
+            _config(**{field: -1.0})
+
+    @pytest.mark.parametrize("field", ["lambda_policy", "lambda_value", "lambda_score"])
+    def test_small_negative_rejected(self, field: str) -> None:
+        """Even tiny negatives flip optimisation direction — reject."""
+        with pytest.raises(ValueError, match=f"{field} must be >= 0"):
+            _config(**{field: -1e-9})
+
+    @pytest.mark.parametrize("field", ["lambda_policy", "lambda_value", "lambda_score"])
+    def test_nan_rejected(self, field: str) -> None:
+        with pytest.raises(ValueError, match=f"{field} must be finite"):
+            _config(**{field: math.nan})
+
+    @pytest.mark.parametrize("field", ["lambda_policy", "lambda_value", "lambda_score"])
+    def test_positive_inf_rejected(self, field: str) -> None:
+        with pytest.raises(ValueError, match=f"{field} must be finite"):
+            _config(**{field: math.inf})
+
+    @pytest.mark.parametrize("field", ["lambda_policy", "lambda_value", "lambda_score"])
+    def test_negative_inf_rejected(self, field: str) -> None:
+        with pytest.raises(ValueError, match=f"{field} must be finite"):
+            _config(**{field: -math.inf})
+
+
+class TestSLConfigPreexistingValidation:
+    """Pre-existing checks must continue to fire — guards against regression in __post_init__ ordering."""
+
+    def test_grad_clip_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match="grad_clip must be > 0"):
+            _config(grad_clip=0.0)
+
+    def test_negative_total_epochs_rejected(self) -> None:
+        with pytest.raises(ValueError, match="total_epochs must be >= 0"):
+            _config(total_epochs=-1)
+
+    def test_zero_batch_size_rejected(self) -> None:
+        with pytest.raises(ValueError, match="batch_size must be > 0"):
+            _config(batch_size=0)
+
+    def test_zero_learning_rate_rejected(self) -> None:
+        with pytest.raises(ValueError, match="learning_rate must be > 0"):
+            _config(learning_rate=0.0)
+
+    def test_negative_num_workers_rejected(self) -> None:
+        with pytest.raises(ValueError, match="num_workers must be >= 0"):
+            _config(num_workers=-1)


### PR DESCRIPTION
## Summary

Three independent P1/P1/P1 bug fixes from the architecture critique
(`docs/arch-analysis-2026-05-05-1007/05-architecture-critique.md`,
weaknesses W5, W1, and the SLConfig half of W11). Each fix is small and
mechanical; each commit is self-contained with regression tests.

| Issue | Bug | Commit |
|---|---|---|
| `keisei-4509042dd1` | Gauntlet tuple-unpacks `MatchOutcome` dataclass — every gauntlet match silently treated as failure | `089149b` |
| `keisei-fa604bad63` | `_record_match_result` writes match + Elo across four separate transactions — partial state on crash | `cf52793` |
| `keisei-678359b7aa` | `SLConfig` accepted negative lambdas — silent gradient ascent on whichever head | `0d231c3` |

W11a (`keisei-ca5e280cae`, `flush_timings()` not called) was already fixed
on main at `katago_loop.py:1618`; verified by running the existing
`test_torch_compile.py::test_*timing*` cases.

The deeper NaN-poisoning bug in `MultiHeadValueAdapter`
(`keisei-bef32b64a8`, originally bundled with the SL fix in the critique)
is structurally larger — needs a graph-connected zero helper across
multiple branches with NaN-path test coverage — and is intentionally
deferred to its own PR.

## Test plan

- [x] `uv run pytest tests/test_historical_gauntlet.py` — 17 pass (15 existing + 2 new)
- [x] `uv run pytest tests/test_league_tournament.py` — 46 pass (44 existing + 2 new)
- [x] `uv run pytest tests/test_sl_config.py` — 24 pass (new file)
- [x] `uv run pytest tests/test_value_adapter.py tests/test_sl_*.py tests/test_concurrent_round.py` — all green
- [x] Full suite: `uv run pytest tests/` — 1616 passed, 1 skipped

## Notes

- The `_record_match_result` atomicity fix relies on `OpponentStore.transaction()`
  being reentrant via `_transaction_depth` — verified at
  `opponent_store.py:436-466`.
- The gauntlet regression test deliberately does NOT mock `play_match` to
  return a tuple — it returns a real `MatchOutcome` instance so the
  unpacking path is exercised.
- The atomicity regression test injects `sqlite3.OperationalError` on the
  second `update_elo` and asserts no `league_results` row, no
  `elo_history` rows, and original Elo / `games_played` survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)